### PR TITLE
lib: encoder: gstobjectfy all vaapi encoders.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapiencoder.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.c
@@ -113,9 +113,9 @@ error_allocation_failed:
 
 /* Generate the common set of encoder properties */
 GPtrArray *
-gst_vaapi_encoder_properties_get_default (const GstVaapiEncoderClass * klass)
+gst_vaapi_encoder_properties_get_default (const GstVaapiEncoderClassData *
+    cdata)
 {
-  const GstVaapiEncoderClassData *const cdata = klass->class_data;
   GPtrArray *props = NULL;
 
   g_assert (cdata->rate_control_get_type != NULL);
@@ -462,7 +462,8 @@ void
 gst_vaapi_encoder_replace (GstVaapiEncoder ** old_encoder_ptr,
     GstVaapiEncoder * new_encoder)
 {
-  gst_vaapi_object_replace (old_encoder_ptr, new_encoder);
+  gst_object_replace ((GstObject **) old_encoder_ptr,
+      (GstObject *) new_encoder);
 }
 
 /* Notifies gst_vaapi_encoder_create_coded_buffer() that a new buffer is free */
@@ -1546,7 +1547,7 @@ error_operation_failed:
 }
 
 /* Initialize default values for configurable properties */
-static gboolean
+gboolean
 gst_vaapi_encoder_init_properties (GstVaapiEncoder * encoder)
 {
   GstVaapiEncoderClass *const klass = GST_VAAPI_ENCODER_GET_CLASS (encoder);
@@ -1569,31 +1570,18 @@ gst_vaapi_encoder_init_properties (GstVaapiEncoder * encoder)
   return TRUE;
 }
 
-/* Base encoder initialization (internal) */
-static gboolean
-gst_vaapi_encoder_init (GstVaapiEncoder * encoder, GstVaapiDisplay * display)
+G_DEFINE_TYPE (GstVaapiEncoder, gst_vaapi_encoder, GST_TYPE_OBJECT);
+
+enum
 {
-  GstVaapiEncoderClass *const klass = GST_VAAPI_ENCODER_GET_CLASS (encoder);
+  ENCODER_PROP_DISPLAY = 1,
+  ENCODER_N_PROPERTIES
+};
 
-  g_return_val_if_fail (display != NULL, FALSE);
-
-#define CHECK_VTABLE_HOOK(FUNC) do {            \
-    if (!klass->FUNC)                           \
-      goto error_invalid_vtable;                \
-  } while (0)
-
-  CHECK_VTABLE_HOOK (init);
-  CHECK_VTABLE_HOOK (finalize);
-  CHECK_VTABLE_HOOK (get_default_properties);
-  CHECK_VTABLE_HOOK (reconfigure);
-  CHECK_VTABLE_HOOK (encode);
-  CHECK_VTABLE_HOOK (reordering);
-  CHECK_VTABLE_HOOK (flush);
-
-#undef CHECK_VTABLE_HOOK
-
-  encoder->display = gst_object_ref (display);
-  encoder->va_display = gst_vaapi_display_get_display (display);
+/* Base encoder initialization (internal) */
+static void
+gst_vaapi_encoder_init (GstVaapiEncoder * encoder)
+{
   encoder->va_context = VA_INVALID_ID;
 
   gst_video_info_init (&encoder->video_info);
@@ -1604,30 +1592,17 @@ gst_vaapi_encoder_init (GstVaapiEncoder * encoder, GstVaapiDisplay * display)
 
   encoder->codedbuf_queue = g_async_queue_new_full ((GDestroyNotify)
       gst_vaapi_coded_buffer_proxy_unref);
-  if (!encoder->codedbuf_queue)
-    return FALSE;
-
-  if (!klass->init (encoder))
-    return FALSE;
-  if (!gst_vaapi_encoder_init_properties (encoder))
-    return FALSE;
-  return TRUE;
-
-  /* ERRORS */
-error_invalid_vtable:
-  {
-    GST_ERROR ("invalid subclass hook (internal error)");
-    return FALSE;
+  if (!encoder->codedbuf_queue) {
+    GST_ERROR ("create encoder->codedbuf_queue failed");
+    return;
   }
 }
 
 /* Base encoder cleanup (internal) */
-void
-gst_vaapi_encoder_finalize (GstVaapiEncoder * encoder)
+static void
+gst_vaapi_encoder_finalize (GObject * object)
 {
-  GstVaapiEncoderClass *const klass = GST_VAAPI_ENCODER_GET_CLASS (encoder);
-
-  klass->finalize (encoder);
+  GstVaapiEncoder *encoder = GST_VAAPI_ENCODER (object);
 
   gst_vaapi_object_replace (&encoder->context, NULL);
   gst_vaapi_display_replace (&encoder->display, NULL);
@@ -1646,6 +1621,8 @@ gst_vaapi_encoder_finalize (GstVaapiEncoder * encoder)
   g_cond_clear (&encoder->surface_free);
   g_cond_clear (&encoder->codedbuf_free);
   g_mutex_clear (&encoder->mutex);
+
+  G_OBJECT_CLASS (gst_vaapi_encoder_parent_class)->finalize (object);
 }
 
 /* Helper function to create new GstVaapiEncoder instances (internal) */
@@ -1653,23 +1630,62 @@ GstVaapiEncoder *
 gst_vaapi_encoder_new (const GstVaapiEncoderClass * klass,
     GstVaapiDisplay * display)
 {
-  GstVaapiEncoder *encoder;
+  return NULL;
+}
 
-  encoder = (GstVaapiEncoder *)
-      gst_vaapi_mini_object_new0 (GST_VAAPI_MINI_OBJECT_CLASS (klass));
-  if (!encoder)
-    return NULL;
+static void
+encoder_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstVaapiEncoder *encoder = GST_VAAPI_ENCODER (object);
 
-  if (!gst_vaapi_encoder_init (encoder, display))
-    goto error;
-  return encoder;
-
-  /* ERRORS */
-error:
-  {
-    gst_vaapi_encoder_unref (encoder);
-    return NULL;
+  switch (prop_id) {
+    case ENCODER_PROP_DISPLAY:
+      g_assert (encoder->display == NULL);
+      encoder->display = g_value_dup_object (value);
+      g_assert (encoder->display != NULL);
+      encoder->va_display = GST_VAAPI_DISPLAY_VADISPLAY (encoder->display);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
   }
+}
+
+static void
+encoder_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstVaapiEncoder *encoder = GST_VAAPI_ENCODER (object);
+
+  switch (prop_id) {
+    case ENCODER_PROP_DISPLAY:
+      g_value_set_object (value, encoder->display);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_vaapi_encoder_class_init (GstVaapiEncoderClass * klass)
+{
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+
+  object_class->set_property = encoder_set_property;
+  object_class->get_property = encoder_get_property;
+  object_class->finalize = gst_vaapi_encoder_finalize;
+
+  /**
+   * GstVaapiDecoder:display:
+   *
+   * #GstVaapiDisplay to be used.
+   */
+  g_object_class_install_property (object_class, ENCODER_PROP_DISPLAY,
+      g_param_spec_object ("display", "Gst VA-API Display",
+          "The VA-API display object to use", GST_TYPE_VAAPI_DISPLAY,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME));
 }
 
 static GstVaapiContext *

--- a/gst-libs/gst/vaapi/gstvaapiencoder.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.h
@@ -29,10 +29,17 @@
 
 G_BEGIN_DECLS
 
-#define GST_VAAPI_ENCODER(encoder) \
-    ((GstVaapiEncoder *) (encoder))
+#define GST_TYPE_VAAPI_ENCODER \
+    (gst_vaapi_encoder_get_type ())
+#define GST_VAAPI_ENCODER(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_VAAPI_ENCODER, GstVaapiEncoder))
+#define GST_VAAPI_IS_ENCODER(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_TYPE_VAAPI_ENCODER))
 
 typedef struct _GstVaapiEncoder GstVaapiEncoder;
+
+GType
+gst_vaapi_encoder_get_type (void) G_GNUC_CONST;
 
 /**
  * GstVaapiEncoderStatus:

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
@@ -3371,10 +3371,17 @@ gst_vaapi_encoder_h264_reconfigure (GstVaapiEncoder * base_encoder)
   return set_context_info (base_encoder);
 }
 
-static gboolean
-gst_vaapi_encoder_h264_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiEncoderH264Class
 {
-  GstVaapiEncoderH264 *const encoder = GST_VAAPI_ENCODER_H264 (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
+
+G_DEFINE_TYPE (GstVaapiEncoderH264, gst_vaapi_encoder_h264,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_h264_init (GstVaapiEncoderH264 * encoder)
+{
   guint32 i;
 
   /* Default encoding entrypoint */
@@ -3411,15 +3418,13 @@ gst_vaapi_encoder_h264_init (GstVaapiEncoder * base_encoder)
 
   encoder->compliance_mode = GST_VAAPI_ENCODER_H264_COMPLIANCE_MODE_STRICT;
   encoder->min_cr = 1;
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_encoder_h264_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_h264_finalize (GObject * object)
 {
   /*free private buffers */
-  GstVaapiEncoderH264 *const encoder = GST_VAAPI_ENCODER_H264 (base_encoder);
+  GstVaapiEncoderH264 *const encoder = GST_VAAPI_ENCODER_H264 (object);
   GstVaapiEncPicture *pic;
   GstVaapiEncoderH264Ref *ref;
   guint32 i;
@@ -3449,6 +3454,8 @@ gst_vaapi_encoder_h264_finalize (GstVaapiEncoder * base_encoder)
     }
     g_queue_clear (&reorder_pool->reorder_frame_list);
   }
+
+  G_OBJECT_CLASS (gst_vaapi_encoder_h264_parent_class)->finalize (object);
 }
 
 static void
@@ -3561,16 +3568,24 @@ gst_vaapi_encoder_h264_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (H264);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_h264_class (void)
+static void
+gst_vaapi_encoder_h264_class_init (GstVaapiEncoderH264Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderH264Class = {
-    GST_VAAPI_ENCODER_CLASS_INIT (H264, h264),
-    .set_property = gst_vaapi_encoder_h264_set_property,
-    .get_codec_data = gst_vaapi_encoder_h264_get_codec_data,
-    .get_pending_reordered = gst_vaapi_encoder_h264_get_pending_reordered,
-  };
-  return &GstVaapiEncoderH264Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_h264_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_h264_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_h264_reordering;
+  encoder_class->encode = gst_vaapi_encoder_h264_encode;
+  encoder_class->flush = gst_vaapi_encoder_h264_flush;
+  encoder_class->set_property = gst_vaapi_encoder_h264_set_property;
+  encoder_class->get_codec_data = gst_vaapi_encoder_h264_get_codec_data;
+  encoder_class->get_pending_reordered =
+      gst_vaapi_encoder_h264_get_pending_reordered;
+  object_class->finalize = gst_vaapi_encoder_h264_finalize;
 }
 
 /**
@@ -3585,7 +3600,19 @@ gst_vaapi_encoder_h264_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_h264_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_h264_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_H264, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -3602,10 +3629,10 @@ gst_vaapi_encoder_h264_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_h264_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_h264_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264.h
@@ -29,10 +29,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_H264 \
+    (gst_vaapi_encoder_h264_get_type ())
 #define GST_VAAPI_ENCODER_H264(encoder) \
-  ((GstVaapiEncoderH264 *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_H264, GstVaapiEncoderH264))
+#define GST_IS_VAAPI_ENCODER_H264(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_H264))
 
 typedef struct _GstVaapiEncoderH264 GstVaapiEncoderH264;
+typedef struct _GstVaapiEncoderH264Class GstVaapiEncoderH264Class;
 
 /**
  * GstVaapiEncoderH264Prop:
@@ -80,6 +85,9 @@ typedef enum {
   GST_VAAPI_ENCODER_H264_PROP_PREDICTION_TYPE = -17,
   GST_VAAPI_ENCODER_H264_PROP_MAX_QP = -18,
 } GstVaapiEncoderH264Prop;
+
+GType
+gst_vaapi_encoder_h264_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_h264_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
@@ -3306,11 +3306,17 @@ gst_vaapi_encoder_h264_fei_reconfigure (GstVaapiEncoder * base_encoder)
   return status;
 }
 
-static gboolean
-gst_vaapi_encoder_h264_fei_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiEncoderH264FeiClass
 {
-  GstVaapiEncoderH264Fei *const encoder =
-      GST_VAAPI_ENCODER_H264_FEI_CAST (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
+
+G_DEFINE_TYPE (GstVaapiEncoderH264Fei, gst_vaapi_encoder_h264_fei,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_h264_fei_init (GstVaapiEncoderH264Fei * encoder)
+{
   guint32 i;
 
   /* Default encoding entrypoint */
@@ -3351,16 +3357,14 @@ gst_vaapi_encoder_h264_fei_init (GstVaapiEncoder * base_encoder)
     ref_pool->max_reflist0_count = 1;
     ref_pool->max_reflist1_count = 1;
   }
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_encoder_h264_fei_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_h264_fei_finalize (GObject * gobject)
 {
   /*free private buffers */
-  GstVaapiEncoderH264Fei *const encoder =
-      GST_VAAPI_ENCODER_H264_FEI_CAST (base_encoder);
+  GstVaapiEncoderH264Fei *const encoder = GST_VAAPI_ENCODER_H264_FEI (gobject);
+  GstVaapiEncoder *base_encoder = GST_VAAPI_ENCODER (gobject);
   GstVaapiEncoder *enc_base_encoder = GST_VAAPI_ENCODER_CAST (encoder->feienc);
   GstVaapiMiniObject *object = GST_VAAPI_MINI_OBJECT (encoder->feipak);
   GstVaapiEncPicture *pic;
@@ -3425,6 +3429,8 @@ gst_vaapi_encoder_h264_fei_finalize (GstVaapiEncoder * base_encoder)
     encoder->ref_pool_ptr = NULL;
     encoder->feienc = NULL;
   }
+
+  G_OBJECT_CLASS (gst_vaapi_encoder_h264_fei_parent_class)->finalize (gobject);
 }
 
 static void
@@ -4001,29 +4007,24 @@ static const GstVaapiEncoderClassData fei_encoder_class_data = {
   .encoder_tune_mask = SUPPORTED_TUNE_OPTIONS,
 };
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_h264_fei_class (void)
+static void
+gst_vaapi_encoder_h264_fei_class_init (GstVaapiEncoderH264FeiClass * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderH264FeiClass = {
-    .parent_class = {
-          .size = sizeof (GstVaapiEncoderH264Fei),
-          .finalize = (GDestroyNotify) gst_vaapi_encoder_finalize,
-        }
-    ,
-    .class_data = &fei_encoder_class_data,
-    .init = gst_vaapi_encoder_h264_fei_init,
-    .finalize = gst_vaapi_encoder_h264_fei_finalize,
-    .reconfigure = gst_vaapi_encoder_h264_fei_reconfigure,
-    .get_default_properties = gst_vaapi_encoder_h264_fei_get_default_properties,
-    .reordering = gst_vaapi_encoder_h264_fei_reordering,
-    .encode = gst_vaapi_encoder_h264_fei_encode,
-    .flush = gst_vaapi_encoder_h264_fei_flush,
-    .set_property = gst_vaapi_encoder_h264_fei_set_property,
-    .get_codec_data = gst_vaapi_encoder_h264_fei_get_codec_data,
-    .ensure_secondary_context =
-        gst_vaapi_encoder_h264_fei_ensure_secondary_context,
-  };
-  return &GstVaapiEncoderH264FeiClass;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &fei_encoder_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_h264_fei_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_h264_fei_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_h264_fei_reordering;
+  encoder_class->encode = gst_vaapi_encoder_h264_fei_encode;
+  encoder_class->flush = gst_vaapi_encoder_h264_fei_flush;
+  encoder_class->set_property = gst_vaapi_encoder_h264_fei_set_property;
+  encoder_class->get_codec_data = gst_vaapi_encoder_h264_fei_get_codec_data;
+  encoder_class->ensure_secondary_context =
+      gst_vaapi_encoder_h264_fei_ensure_secondary_context;
+  object_class->finalize = gst_vaapi_encoder_h264_fei_finalize;
 }
 
 /**
@@ -4040,10 +4041,10 @@ gst_vaapi_encoder_h264_fei_class (void)
 GPtrArray *
 gst_vaapi_encoder_h264_fei_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_h264_fei_class ();
+  const GstVaapiEncoderClassData *class_data = &fei_encoder_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 
@@ -4336,31 +4337,47 @@ GstVaapiEncoder *
 gst_vaapi_encoder_h264_fei_new (GstVaapiDisplay * display)
 {
   GstVaapiEncoder *base_encoder;
-  GstVaapiEncoderH264Fei *feiencoder;
-  GstVaapiFeiEncH264 *feienc;
-  GstVaapiFEIPakH264 *feipak;
+  GstVaapiEncoderH264Fei *feiencoder = NULL;
+  GstVaapiFeiEncH264 *feienc = NULL;
+  GstVaapiFEIPakH264 *feipak = NULL;
+  gboolean ret;
 
   /* create FEIEncoderObject: Default mode of operation in ENC_PAK */
   base_encoder =
-      gst_vaapi_encoder_new (gst_vaapi_encoder_h264_fei_class (), display);
+      g_object_new (GST_TYPE_VAAPI_ENCODER_H264_FEI, "display", display, NULL);
   if (!base_encoder)
     return NULL;
   feiencoder = GST_VAAPI_ENCODER_H264_FEI_CAST (base_encoder);
+  /* TODO: init_properties can not be called in _init function, the "display"
+     property can just be set correctly after _init function */
+  ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (feiencoder));
+  if (!ret)
+    goto error;
 
   /* create an enc object */
-  feienc = GST_VAAPI_FEI_H264_ENC (gst_vaapi_feienc_h264_new (display));
+  feienc = GST_VAAPI_FEI_ENC_H264 (gst_vaapi_feienc_h264_new (display));
   if (!feienc)
-    return NULL;
+    goto error;
 
   /* create a pak object */
   feipak =
       gst_vaapi_feipak_h264_new (base_encoder, display,
       base_encoder->va_context);
   if (!feipak)
-    return NULL;
+    goto error;
 
   feiencoder->feienc = feienc;
   feiencoder->feipak = feipak;
 
   return base_encoder;
+
+error:
+  if (feienc)
+    g_object_unref (feienc);
+  if (feipak)
+    gst_vaapi_mini_object_replace ((GstVaapiMiniObject **) & feipak, NULL);
+  if (feiencoder)
+    g_object_unref (feiencoder);
+
+  return NULL;
 }

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.h
@@ -30,10 +30,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_H264_FEI \
+    (gst_vaapi_encoder_h264_fei_get_type ())
 #define GST_VAAPI_ENCODER_H264_FEI(encoder) \
-  ((GstVaapiEncoderH264Fei *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_H264_FEI, GstVaapiEncoderH264Fei))
+#define GST_IS_VAAPI_ENCODER_H264_FEI(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_H264_FEI))
 
 typedef struct _GstVaapiEncoderH264Fei GstVaapiEncoderH264Fei;
+typedef struct _GstVaapiEncoderH264FeiClass GstVaapiEncoderH264FeiClass;
 
 /**
  * GstVaapiEncoderH264FeiProp:
@@ -84,6 +89,9 @@ typedef enum {
   GST_VAAPI_ENCODER_H264_FEI_PROP_MAX_QP = -29,
 
 } GstVaapiEncoderH264FeiProp;
+
+GType
+gst_vaapi_encoder_h264_fei_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_h264_fei_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
@@ -827,8 +827,8 @@ bs_write_slice (GstBitWriter * bs,
             || slice_param->slice_fields.bits.slice_sao_chroma_flag
             || !slice_deblocking_filter_disabled_flag))
       WRITE_UINT32 (bs,
-          slice_param->slice_fields.bits.
-          slice_loop_filter_across_slices_enabled_flag, 1);
+          slice_param->slice_fields.
+          bits.slice_loop_filter_across_slices_enabled_flag, 1);
 
   }
 
@@ -1787,8 +1787,8 @@ add_slice_headers (GstVaapiEncoderH265 * encoder, GstVaapiEncPicture * picture,
       }
     }
 
-    slice_param->slice_fields.bits.
-        slice_loop_filter_across_slices_enabled_flag = TRUE;
+    slice_param->slice_fields.
+        bits.slice_loop_filter_across_slices_enabled_flag = TRUE;
 
     /* set calculation for next slice */
     last_ctu_index += cur_slice_ctus;
@@ -2594,10 +2594,9 @@ gst_vaapi_encoder_h265_reconfigure (GstVaapiEncoder * base_encoder)
   return set_context_info (base_encoder);
 }
 
-static gboolean
-gst_vaapi_encoder_h265_init (GstVaapiEncoder * base_encoder)
+static void
+gst_vaapi_encoder_h265_init (GstVaapiEncoderH265 * encoder)
 {
-  GstVaapiEncoderH265 *const encoder = GST_VAAPI_ENCODER_H265 (base_encoder);
   GstVaapiH265ReorderPool *reorder_pool;
   GstVaapiH265RefPool *ref_pool;
 
@@ -2620,15 +2619,21 @@ gst_vaapi_encoder_h265_init (GstVaapiEncoder * base_encoder)
   ref_pool->max_ref_frames = 0;
   ref_pool->max_reflist0_count = 1;
   ref_pool->max_reflist1_count = 1;
-
-  return TRUE;
 }
 
+struct _GstVaapiEncoderH265Class
+{
+  GstVaapiEncoderClass parent_class;
+};
+
+G_DEFINE_TYPE (GstVaapiEncoderH265, gst_vaapi_encoder_h265,
+    GST_TYPE_VAAPI_ENCODER);
+
 static void
-gst_vaapi_encoder_h265_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_h265_finalize (GObject * object)
 {
   /*free private buffers */
-  GstVaapiEncoderH265 *const encoder = GST_VAAPI_ENCODER_H265 (base_encoder);
+  GstVaapiEncoderH265 *const encoder = GST_VAAPI_ENCODER_H265 (object);
   GstVaapiEncPicture *pic;
   GstVaapiEncoderH265Ref *ref;
   GstVaapiH265RefPool *ref_pool;
@@ -2654,6 +2659,8 @@ gst_vaapi_encoder_h265_finalize (GstVaapiEncoder * base_encoder)
     gst_vaapi_enc_picture_unref (pic);
   }
   g_queue_clear (&reorder_pool->reorder_frame_list);
+
+  G_OBJECT_CLASS (gst_vaapi_encoder_h265_parent_class)->finalize (object);
 }
 
 static GstVaapiEncoderStatus
@@ -2705,16 +2712,24 @@ gst_vaapi_encoder_h265_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (H265);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_h265_class (void)
+static void
+gst_vaapi_encoder_h265_class_init (GstVaapiEncoderH265Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderH265Class = {
-    GST_VAAPI_ENCODER_CLASS_INIT (H265, h265),
-    .set_property = gst_vaapi_encoder_h265_set_property,
-    .get_codec_data = gst_vaapi_encoder_h265_get_codec_data,
-    .get_pending_reordered = gst_vaapi_encoder_h265_get_pending_reordered,
-  };
-  return &GstVaapiEncoderH265Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_h265_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_h265_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_h265_reordering;
+  encoder_class->encode = gst_vaapi_encoder_h265_encode;
+  encoder_class->flush = gst_vaapi_encoder_h265_flush;
+  encoder_class->set_property = gst_vaapi_encoder_h265_set_property;
+  encoder_class->get_codec_data = gst_vaapi_encoder_h265_get_codec_data;
+  encoder_class->get_pending_reordered =
+      gst_vaapi_encoder_h265_get_pending_reordered;
+  object_class->finalize = gst_vaapi_encoder_h265_finalize;
 }
 
 /**
@@ -2729,7 +2744,19 @@ gst_vaapi_encoder_h265_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_h265_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_h265_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_H265, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -2746,10 +2773,10 @@ gst_vaapi_encoder_h265_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_h265_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_h265_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h265.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h265.h
@@ -28,10 +28,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_H265 \
+    (gst_vaapi_encoder_h265_get_type ())
 #define GST_VAAPI_ENCODER_H265(encoder) \
-  ((GstVaapiEncoderH265 *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_H265, GstVaapiEncoderH265))
+#define GST_IS_VAAPI_ENCODER_H265(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_H265))
 
 typedef struct _GstVaapiEncoderH265 GstVaapiEncoderH265;
+typedef struct _GstVaapiEncoderH265Class GstVaapiEncoderH265Class;
 
 /**
  * GstVaapiEncoderH265Prop:
@@ -64,6 +69,9 @@ typedef enum {
   GST_VAAPI_ENCODER_H265_PROP_LOW_DELAY_B = -11,
   GST_VAAPI_ENCODER_H265_PROP_MAX_QP = -12,
 } GstVaapiEncoderH265Prop;
+
+GType
+gst_vaapi_encoder_h265_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_h265_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
@@ -743,24 +743,29 @@ gst_vaapi_encoder_jpeg_reconfigure (GstVaapiEncoder * base_encoder)
   return set_context_info (base_encoder);
 }
 
-static gboolean
-gst_vaapi_encoder_jpeg_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiEncoderJpegClass
 {
-  GstVaapiEncoderJpeg *const encoder = GST_VAAPI_ENCODER_JPEG (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
 
+G_DEFINE_TYPE (GstVaapiEncoderJpeg, gst_vaapi_encoder_jpeg,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_jpeg_init (GstVaapiEncoderJpeg * encoder)
+{
   encoder->has_quant_tables = FALSE;
   memset (&encoder->quant_tables, 0, sizeof (encoder->quant_tables));
   memset (&encoder->scaled_quant_tables, 0,
       sizeof (encoder->scaled_quant_tables));
   encoder->has_huff_tables = FALSE;
   memset (&encoder->huff_tables, 0, sizeof (encoder->huff_tables));
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_encoder_jpeg_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_jpeg_finalize (GObject * object)
 {
+  G_OBJECT_CLASS (gst_vaapi_encoder_jpeg_parent_class)->finalize (object);
 }
 
 static GstVaapiEncoderStatus
@@ -781,14 +786,21 @@ gst_vaapi_encoder_jpeg_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (JPEG);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_jpeg_class (void)
+static void
+gst_vaapi_encoder_jpeg_class_init (GstVaapiEncoderJpegClass * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderJpegClass = {
-    GST_VAAPI_ENCODER_CLASS_INIT (Jpeg, jpeg),
-    .set_property = gst_vaapi_encoder_jpeg_set_property,
-  };
-  return &GstVaapiEncoderJpegClass;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_jpeg_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_jpeg_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_jpeg_reordering;
+  encoder_class->encode = gst_vaapi_encoder_jpeg_encode;
+  encoder_class->flush = gst_vaapi_encoder_jpeg_flush;
+  encoder_class->set_property = gst_vaapi_encoder_jpeg_set_property;
+  object_class->finalize = gst_vaapi_encoder_jpeg_finalize;
 }
 
 /**
@@ -802,7 +814,19 @@ gst_vaapi_encoder_jpeg_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_jpeg_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_jpeg_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_JPEG, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -819,10 +843,10 @@ gst_vaapi_encoder_jpeg_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_jpeg_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_jpeg_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.h
@@ -27,10 +27,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_JPEG \
+    (gst_vaapi_encoder_jpeg_get_type ())
 #define GST_VAAPI_ENCODER_JPEG(encoder) \
-  ((GstVaapiEncoderJpeg *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_JPEG, GstVaapiEncoderJpeg))
+#define GST_IS_VAAPI_ENCODER_JPEG(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_JPEG))
 
 typedef struct _GstVaapiEncoderJpeg GstVaapiEncoderJpeg;
+typedef struct _GstVaapiEncoderJpegClass GstVaapiEncoderJpegClass;
 
 /**
  * GstVaapiEncoderJpegProp:
@@ -41,6 +46,9 @@ typedef struct _GstVaapiEncoderJpeg GstVaapiEncoderJpeg;
 typedef enum {
   GST_VAAPI_ENCODER_JPEG_PROP_QUALITY = -1
 } GstVaapiEncoderJpegProp;
+
+GType
+gst_vaapi_encoder_jpeg_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_jpeg_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.c
@@ -719,16 +719,19 @@ error:
   }
 }
 
-static gboolean
-gst_vaapi_encoder_mpeg2_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiEncoderMpeg2Class
 {
-  GstVaapiEncoderMpeg2 *const encoder =
-      GST_VAAPI_ENCODER_MPEG2_CAST (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
 
+G_DEFINE_TYPE (GstVaapiEncoderMpeg2, gst_vaapi_encoder_mpeg2,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_mpeg2_init (GstVaapiEncoderMpeg2 * encoder)
+{
   /* re-ordering */
   g_queue_init (&encoder->b_frames);
-
-  return TRUE;
 }
 
 static void
@@ -762,11 +765,10 @@ push_reference (GstVaapiEncoderMpeg2 * encoder, GstVaapiSurfaceProxy * ref)
 }
 
 static void
-gst_vaapi_encoder_mpeg2_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_mpeg2_finalize (GObject * object)
 {
   /* free private buffers */
-  GstVaapiEncoderMpeg2 *const encoder =
-      GST_VAAPI_ENCODER_MPEG2_CAST (base_encoder);
+  GstVaapiEncoderMpeg2 *const encoder = GST_VAAPI_ENCODER_MPEG2 (object);
   GstVaapiEncPicture *pic;
 
   clear_references (encoder);
@@ -776,6 +778,8 @@ gst_vaapi_encoder_mpeg2_finalize (GstVaapiEncoder * base_encoder)
     gst_vaapi_enc_picture_unref (pic);
   }
   g_queue_clear (&encoder->b_frames);
+
+  G_OBJECT_CLASS (gst_vaapi_encoder_mpeg2_parent_class)->finalize (object);
 }
 
 static GstVaapiEncoderStatus
@@ -800,14 +804,21 @@ gst_vaapi_encoder_mpeg2_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (MPEG2);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_mpeg2_class (void)
+static void
+gst_vaapi_encoder_mpeg2_class_init (GstVaapiEncoderMpeg2Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderMpeg2Class = {
-    GST_VAAPI_ENCODER_CLASS_INIT (Mpeg2, mpeg2),
-    .set_property = gst_vaapi_encoder_mpeg2_set_property,
-  };
-  return &GstVaapiEncoderMpeg2Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_mpeg2_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_mpeg2_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_mpeg2_reordering;
+  encoder_class->encode = gst_vaapi_encoder_mpeg2_encode;
+  encoder_class->flush = gst_vaapi_encoder_mpeg2_flush;
+  encoder_class->set_property = gst_vaapi_encoder_mpeg2_set_property;
+  object_class->finalize = gst_vaapi_encoder_mpeg2_finalize;
 }
 
 /**
@@ -821,7 +832,19 @@ gst_vaapi_encoder_mpeg2_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_mpeg2_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_mpeg2_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_MPEG2, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -838,10 +861,10 @@ gst_vaapi_encoder_mpeg2_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_mpeg2_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_mpeg2_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.h
@@ -28,10 +28,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_MPEG2 \
+    (gst_vaapi_encoder_mpeg2_get_type ())
 #define GST_VAAPI_ENCODER_MPEG2(encoder) \
-  ((GstVaapiEncoderMpeg2 *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_MPEG2, GstVaapiEncoderMpeg2))
+#define GST_IS_VAAPI_ENCODER_MPEG2(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_MPEG2))
 
 typedef struct _GstVaapiEncoderMpeg2 GstVaapiEncoderMpeg2;
+typedef struct _GstVaapiEncoderMpeg2Class GstVaapiEncoderMpeg2Class;
 
 /**
  * GstVaapiEncoderMpeg2Prop:
@@ -45,6 +50,9 @@ typedef enum {
   GST_VAAPI_ENCODER_MPEG2_PROP_QUANTIZER = -1,
   GST_VAAPI_ENCODER_MPEG2_PROP_MAX_BFRAMES = -2,
 } GstVaapiEncoderMpeg2Prop;
+
+GType
+gst_vaapi_encoder_mpeg2_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_mpeg2_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_priv.h
@@ -37,10 +37,10 @@ G_BEGIN_DECLS
     ((GstVaapiEncoder *)(encoder))
 
 #define GST_VAAPI_ENCODER_CLASS(klass) \
-    ((GstVaapiEncoderClass *)(klass))
+    (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_VAAPI_ENCODER, GstVaapiEncoderClass))
 
 #define GST_VAAPI_ENCODER_GET_CLASS(obj) \
-    GST_VAAPI_ENCODER_CLASS(GST_VAAPI_MINI_OBJECT_GET_CLASS(obj))
+    (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_VAAPI_ENCODER, GstVaapiEncoderClass))
 
 /**
  * GST_VAAPI_ENCODER_PACKED_HEADERS:
@@ -240,12 +240,12 @@ gst_vaapi_encoder_properties_append (GPtrArray * props, gint prop_id,
 
 G_GNUC_INTERNAL
 GPtrArray *
-gst_vaapi_encoder_properties_get_default (const GstVaapiEncoderClass * klass);
+gst_vaapi_encoder_properties_get_default (const GstVaapiEncoderClassData *cdata);
 
 struct _GstVaapiEncoder
 {
   /*< private >*/
-  GstVaapiMiniObject parent_instance;
+  GstObject parent_instance;
 
   GPtrArray *properties;
   GstVaapiDisplay *display;
@@ -337,12 +337,9 @@ struct _GstVaapiEncoderClassData
 struct _GstVaapiEncoderClass
 {
   /*< private >*/
-  GstVaapiMiniObjectClass parent_class;
+  GstObjectClass parent_class;
 
   const GstVaapiEncoderClassData *class_data;
-
-  gboolean              (*init)         (GstVaapiEncoder * encoder);
-  void                  (*finalize)     (GstVaapiEncoder * encoder);
 
   GstVaapiEncoderStatus (*reconfigure)  (GstVaapiEncoder * encoder);
 
@@ -400,8 +397,8 @@ gst_vaapi_encoder_new (const GstVaapiEncoderClass * klass,
     GstVaapiDisplay * display);
 
 G_GNUC_INTERNAL
-void
-gst_vaapi_encoder_finalize (GstVaapiEncoder * encoder);
+gboolean
+gst_vaapi_encoder_init_properties (GstVaapiEncoder * encoder);
 
 G_GNUC_INTERNAL
 GstVaapiSurfaceProxy *

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp8.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp8.c
@@ -510,24 +510,29 @@ error:
   }
 }
 
-static gboolean
-gst_vaapi_encoder_vp8_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiEncoderVP8Class
 {
-  GstVaapiEncoderVP8 *const encoder = GST_VAAPI_ENCODER_VP8 (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
 
+G_DEFINE_TYPE (GstVaapiEncoderVP8, gst_vaapi_encoder_vp8,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_vp8_init (GstVaapiEncoderVP8 * encoder)
+{
   encoder->frame_num = 0;
   encoder->last_ref = NULL;
   encoder->golden_ref = NULL;
   encoder->alt_ref = NULL;
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_encoder_vp8_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_vp8_finalize (GObject * object)
 {
-  GstVaapiEncoderVP8 *const encoder = GST_VAAPI_ENCODER_VP8 (base_encoder);
+  GstVaapiEncoderVP8 *const encoder = GST_VAAPI_ENCODER_VP8 (object);
   clear_references (encoder);
+  G_OBJECT_CLASS (gst_vaapi_encoder_vp8_parent_class)->finalize (object);
 }
 
 static GstVaapiEncoderStatus
@@ -554,14 +559,21 @@ gst_vaapi_encoder_vp8_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (VP8);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_vp8_class (void)
+static void
+gst_vaapi_encoder_vp8_class_init (GstVaapiEncoderVP8Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderVP8Class = {
-    GST_VAAPI_ENCODER_CLASS_INIT (VP8, vp8),
-    .set_property = gst_vaapi_encoder_vp8_set_property,
-  };
-  return &GstVaapiEncoderVP8Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_vp8_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_vp8_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_vp8_reordering;
+  encoder_class->encode = gst_vaapi_encoder_vp8_encode;
+  encoder_class->flush = gst_vaapi_encoder_vp8_flush;
+  encoder_class->set_property = gst_vaapi_encoder_vp8_set_property;
+  object_class->finalize = gst_vaapi_encoder_vp8_finalize;
 }
 
 /**
@@ -575,7 +587,20 @@ gst_vaapi_encoder_vp8_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_vp8_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_vp8_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_VP8, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
+
 }
 
 /**
@@ -592,10 +617,10 @@ gst_vaapi_encoder_vp8_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_vp8_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_vp8_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 
@@ -619,7 +644,9 @@ gst_vaapi_encoder_vp8_get_default_properties (void)
       GST_VAAPI_ENCODER_VP8_PROP_YAC_Q_INDEX,
       g_param_spec_uint ("yac-qi",
           "Luma AC Quant Table index",
-          "Quantization Table index for Luma AC Coefficients, (in default case, yac_qi=4 for key frames and yac_qi=40 for P frames)",
+          "Quantization Table index for Luma AC Coefficients,"
+          " (in default case, yac_qi=4 for key frames and yac_qi=40"
+          " for P frames)",
           0, 127, DEFAULT_YAC_QI, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   return props;

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp8.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp8.h
@@ -27,10 +27,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_VP8 \
+    (gst_vaapi_encoder_vp8_get_type ())
 #define GST_VAAPI_ENCODER_VP8(encoder) \
-  ((GstVaapiEncoderVP8 *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_VP8, GstVaapiEncoderVP8))
+#define GST_IS_VAAPI_ENCODER_VP8(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_VP8))
 
 typedef struct _GstVaapiEncoderVP8 GstVaapiEncoderVP8;
+typedef struct _GstVaapiEncoderVP8Class GstVaapiEncoderVP8Class;
 
 /**
  * GstVaapiEncoderVP8Prop:
@@ -45,6 +50,9 @@ typedef enum {
   GST_VAAPI_ENCODER_VP8_PROP_SHARPNESS_LEVEL = -2,
   GST_VAAPI_ENCODER_VP8_PROP_YAC_Q_INDEX = -3
 } GstVaapiEncoderVP8Prop;
+
+GType
+gst_vaapi_encoder_vp8_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_vp8_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
@@ -417,8 +417,8 @@ update_ref_list (GstVaapiEncoderVP9 * encoder, GstVaapiEncPicture * picture,
       gst_vaapi_surface_proxy_unref (ref);
       break;
     case GST_VAAPI_ENCODER_VP9_REF_PIC_MODE_1:
-      gst_vaapi_surface_proxy_replace (&encoder->
-          ref_list[encoder->ref_list_idx], ref);
+      gst_vaapi_surface_proxy_replace (&encoder->ref_list[encoder->
+              ref_list_idx], ref);
       gst_vaapi_surface_proxy_unref (ref);
       encoder->ref_list_idx = (encoder->ref_list_idx + 1) % GST_VP9_REF_FRAMES;
       break;
@@ -522,11 +522,18 @@ gst_vaapi_encoder_vp9_reconfigure (GstVaapiEncoder * base_encoder)
   return set_context_info (base_encoder);
 }
 
-static gboolean
-gst_vaapi_encoder_vp9_init (GstVaapiEncoder * base_encoder)
-{
-  GstVaapiEncoderVP9 *const encoder = GST_VAAPI_ENCODER_VP9 (base_encoder);
 
+struct _GstVaapiEncoderVP9Class
+{
+  GstVaapiEncoderClass parent_class;
+};
+
+G_DEFINE_TYPE (GstVaapiEncoderVP9, gst_vaapi_encoder_vp9,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_encoder_vp9_init (GstVaapiEncoderVP9 * encoder)
+{
   encoder->frame_num = 0;
   encoder->loop_filter_level = DEFAULT_LOOP_FILTER_LEVEL;
   encoder->sharpness_level = DEFAULT_SHARPNESS_LEVEL;
@@ -537,13 +544,12 @@ gst_vaapi_encoder_vp9_init (GstVaapiEncoder * base_encoder)
   memset (encoder->ref_list, 0,
       G_N_ELEMENTS (encoder->ref_list) * sizeof (encoder->ref_list[0]));
   encoder->ref_list_idx = 0;
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_encoder_vp9_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_encoder_vp9_finalize (GObject * object)
 {
+  G_OBJECT_CLASS (gst_vaapi_encoder_vp9_parent_class)->finalize (object);
 }
 
 static GstVaapiEncoderStatus
@@ -576,14 +582,21 @@ gst_vaapi_encoder_vp9_set_property (GstVaapiEncoder * base_encoder,
 
 GST_VAAPI_ENCODER_DEFINE_CLASS_DATA (VP9);
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_encoder_vp9_class (void)
+static void
+gst_vaapi_encoder_vp9_class_init (GstVaapiEncoderVP9Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiEncoderVP9Class = {
-    GST_VAAPI_ENCODER_CLASS_INIT (VP9, vp9),
-    .set_property = gst_vaapi_encoder_vp9_set_property,
-  };
-  return &GstVaapiEncoderVP9Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &g_class_data;
+  encoder_class->reconfigure = gst_vaapi_encoder_vp9_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_encoder_vp9_get_default_properties;
+  encoder_class->reordering = gst_vaapi_encoder_vp9_reordering;
+  encoder_class->encode = gst_vaapi_encoder_vp9_encode;
+  encoder_class->flush = gst_vaapi_encoder_vp9_flush;
+  encoder_class->set_property = gst_vaapi_encoder_vp9_set_property;
+  object_class->finalize = gst_vaapi_encoder_vp9_finalize;
 }
 
 /**
@@ -597,7 +610,19 @@ gst_vaapi_encoder_vp9_class (void)
 GstVaapiEncoder *
 gst_vaapi_encoder_vp9_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_encoder_vp9_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_ENCODER_VP9, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -614,10 +639,10 @@ gst_vaapi_encoder_vp9_new (GstVaapiDisplay * display)
 GPtrArray *
 gst_vaapi_encoder_vp9_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_encoder_vp9_class ();
+  const GstVaapiEncoderClassData *class_data = &g_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
   if (!props)
     return NULL;
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp9.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp9.h
@@ -27,10 +27,15 @@
 
 G_BEGIN_DECLS
 
+#define GST_TYPE_VAAPI_ENCODER_VP9 \
+    (gst_vaapi_encoder_vp9_get_type ())
 #define GST_VAAPI_ENCODER_VP9(encoder) \
-  ((GstVaapiEncoderVP9 *) (encoder))
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_ENCODER_VP9, GstVaapiEncoderVP9))
+#define GST_IS_VAAPI_ENCODER_VP9(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_ENCODER_VP9))
 
 typedef struct _GstVaapiEncoderVP9 GstVaapiEncoderVP9;
+typedef struct _GstVaapiEncoderVP9Class GstVaapiEncoderVP9Class;
 
 /**
  * GstVaapiEncoderVP9Prop:
@@ -49,6 +54,9 @@ typedef enum {
   GST_VAAPI_ENCODER_VP9_PROP_REF_PIC_MODE = -4,
   GST_VAAPI_ENCODER_VP9_PROP_CPB_LENGTH = -5
 } GstVaapiEncoderVP9Prop;
+
+GType
+gst_vaapi_encoder_vp9_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_encoder_vp9_new (GstVaapiDisplay * display);

--- a/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
@@ -184,7 +184,7 @@ h264_get_cpb_nal_factor (GstVaapiProfile profile)
 /* --- FEI Enc                                                           --- */
 /* ------------------------------------------------------------------------- */
 
-#define GST_VAAPI_FEI_H264_ENC_CAST(feienc) \
+#define GST_VAAPI_FEI_ENC_H264_CAST(feienc) \
     ((GstVaapiFeiEncH264 *)(feienc))
 
 struct _GstVaapiFeiEncH264
@@ -1380,7 +1380,7 @@ gst_vaapi_feienc_h264_encode (GstVaapiEncoder * base_encoder,
     GstVaapiCodedBufferProxy * codedbuf_proxy,
     GstVaapiFeiInfoToPakH264 * info_to_pak)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
   GstVaapiEncoderStatus ret = GST_VAAPI_ENCODER_STATUS_ERROR_UNKNOWN;
 
   if (!reconstruct || !codedbuf_proxy)
@@ -1410,7 +1410,7 @@ error:
 GstVaapiEncoderStatus
 gst_vaapi_feienc_h264_flush (GstVaapiEncoder * base_encoder)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
   GstVaapiH264ViewReorderPool *reorder_pool;
   GstVaapiEncPicture *pic;
   guint i;
@@ -1444,7 +1444,7 @@ GstVaapiEncoderStatus
 gst_vaapi_feienc_h264_reordering (GstVaapiEncoder * base_encoder,
     GstVideoCodecFrame * frame, GstVaapiEncPicture ** output)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
   GstVaapiH264ViewReorderPool *reorder_pool = NULL;
   GstVaapiEncPicture *picture;
   gboolean is_idr = FALSE;
@@ -1554,7 +1554,7 @@ end:
 static GstVaapiEncoderStatus
 set_context_info (GstVaapiEncoder * base_encoder)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
   GstVideoInfo *const vip = GST_VAAPI_ENCODER_VIDEO_INFO (feienc);
   const guint DEFAULT_SURFACES_COUNT = 3;
 
@@ -1601,7 +1601,7 @@ set_context_info (GstVaapiEncoder * base_encoder)
 GstVaapiEncoderStatus
 gst_vaapi_feienc_h264_reconfigure (GstVaapiEncoder * base_encoder)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
   GstVideoInfo *const vip = GST_VAAPI_ENCODER_VIDEO_INFO (feienc);
   GstVaapiEncoderStatus status;
   guint mb_width, mb_height;
@@ -1637,10 +1637,17 @@ gst_vaapi_feienc_h264_reconfigure (GstVaapiEncoder * base_encoder)
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;
 }
 
-static gboolean
-gst_vaapi_feienc_h264_init (GstVaapiEncoder * base_encoder)
+struct _GstVaapiFeiEncH264Class
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiEncoderClass parent_class;
+};
+
+G_DEFINE_TYPE (GstVaapiFeiEncH264, gst_vaapi_feienc_h264,
+    GST_TYPE_VAAPI_ENCODER);
+
+static void
+gst_vaapi_feienc_h264_init (GstVaapiFeiEncH264 * feienc)
+{
   guint32 i;
 
   /* Default encoding entrypoint */
@@ -1672,15 +1679,13 @@ gst_vaapi_feienc_h264_init (GstVaapiEncoder * base_encoder)
     reorder_pool->cur_frame_num = 0;
     reorder_pool->cur_present_index = 0;
   }
-
-  return TRUE;
 }
 
 static void
-gst_vaapi_feienc_h264_finalize (GstVaapiEncoder * base_encoder)
+gst_vaapi_feienc_h264_finalize (GObject * object)
 {
   /*free private buffers */
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264 (object);
   GstVaapiEncPicture *pic;
   guint32 i;
 
@@ -1698,6 +1703,8 @@ gst_vaapi_feienc_h264_finalize (GstVaapiEncoder * base_encoder)
     }
     g_queue_clear (&reorder_pool->reorder_frame_list);
   }
+
+  G_OBJECT_CLASS (gst_vaapi_feienc_h264_parent_class)->finalize (object);
 }
 
 static void
@@ -1744,7 +1751,7 @@ GstVaapiEncoderStatus
 gst_vaapi_feienc_h264_set_property (GstVaapiEncoder * base_encoder,
     gint prop_id, const GValue * value)
 {
-  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_H264_ENC_CAST (base_encoder);
+  GstVaapiFeiEncH264 *const feienc = GST_VAAPI_FEI_ENC_H264_CAST (base_encoder);
 
   switch (prop_id) {
     case GST_VAAPI_FEI_H264_ENC_PROP_MAX_BFRAMES:
@@ -1839,27 +1846,22 @@ static const GstVaapiEncoderClassData fei_enc_class_data = {
   .encoder_tune_mask = SUPPORTED_TUNE_OPTIONS,
 };
 
-static inline const GstVaapiEncoderClass *
-gst_vaapi_feienc_h264_class (void)
+static void
+gst_vaapi_feienc_h264_class_init (GstVaapiFeiEncH264Class * klass)
 {
-  static const GstVaapiEncoderClass GstVaapiFeiEncH264Class = {
-    .parent_class = {
-          .size = sizeof (GstVaapiFeiEncH264),
-          .finalize = (GDestroyNotify) gst_vaapi_encoder_finalize,
-        }
-    ,
-    .class_data = &fei_enc_class_data,
-    .init = gst_vaapi_feienc_h264_init,
-    .finalize = gst_vaapi_feienc_h264_finalize,
-    .reconfigure = gst_vaapi_feienc_h264_reconfigure,
-    .get_default_properties = gst_vaapi_feienc_h264_get_default_properties,
-    .reordering = gst_vaapi_feienc_h264_reordering,
-    .encode = gst_vaapi_feienc_h264_fake_encode,
-    .flush = gst_vaapi_feienc_h264_flush,
-    .set_property = gst_vaapi_feienc_h264_set_property,
-    .get_codec_data = gst_vaapi_feienc_h264_get_codec_data,
-  };
-  return &GstVaapiFeiEncH264Class;
+  GObjectClass *const object_class = G_OBJECT_CLASS (klass);
+  GstVaapiEncoderClass *const encoder_class = GST_VAAPI_ENCODER_CLASS (klass);
+
+  encoder_class->class_data = &fei_enc_class_data;
+  encoder_class->reconfigure = gst_vaapi_feienc_h264_reconfigure;
+  encoder_class->get_default_properties =
+      gst_vaapi_feienc_h264_get_default_properties;
+  encoder_class->reordering = gst_vaapi_feienc_h264_reordering;
+  encoder_class->encode = gst_vaapi_feienc_h264_fake_encode;
+  encoder_class->flush = gst_vaapi_feienc_h264_flush;
+  encoder_class->set_property = gst_vaapi_feienc_h264_set_property;
+  encoder_class->get_codec_data = gst_vaapi_feienc_h264_get_codec_data;
+  object_class->finalize = gst_vaapi_feienc_h264_finalize;
 }
 
 /**
@@ -1874,7 +1876,19 @@ gst_vaapi_feienc_h264_class (void)
 GstVaapiEncoder *
 gst_vaapi_feienc_h264_new (GstVaapiDisplay * display)
 {
-  return gst_vaapi_encoder_new (gst_vaapi_feienc_h264_class (), display);
+  gboolean ret;
+  GstVaapiEncoder *encoder =
+      g_object_new (GST_TYPE_VAAPI_FEI_ENC_H264, "display", display, NULL);
+  if (encoder) {
+    /* TODO: init_properties can not be called in _init function, the "display"
+       property can just be set correctly after _init function */
+    ret = gst_vaapi_encoder_init_properties (GST_VAAPI_ENCODER (encoder));
+    if (!ret) {
+      g_object_unref (encoder);
+      encoder = NULL;
+    }
+  }
+  return encoder;
 }
 
 /**
@@ -2071,10 +2085,10 @@ gst_vaapi_feienc_h264_get_fei_properties (GPtrArray * props)
 GPtrArray *
 gst_vaapi_feienc_h264_get_default_properties (void)
 {
-  const GstVaapiEncoderClass *const klass = gst_vaapi_feienc_h264_class ();
+  const GstVaapiEncoderClassData *class_data = &fei_enc_class_data;
   GPtrArray *props;
 
-  props = gst_vaapi_encoder_properties_get_default (klass);
+  props = gst_vaapi_encoder_properties_get_default (class_data);
 
   if (!props)
     return NULL;

--- a/gst-libs/gst/vaapi/gstvaapifeienc_h264.h
+++ b/gst-libs/gst/vaapi/gstvaapifeienc_h264.h
@@ -29,9 +29,16 @@
 #include <gst/vaapi/gstvaapifeiutils_h264.h>
 #include <gst/vaapi/gstvaapifei_objects_priv.h>
 G_BEGIN_DECLS
-#define GST_VAAPI_FEI_H264_ENC(feienc) \
-  ((GstVaapiFeiEncH264 *) (feienc))
+
+#define GST_TYPE_VAAPI_FEI_ENC_H264 \
+    (gst_vaapi_feienc_h264_get_type ())
+#define GST_VAAPI_FEI_ENC_H264(encoder) \
+    (G_TYPE_CHECK_INSTANCE_CAST ((encoder), GST_TYPE_VAAPI_FEI_ENC_H264, GstVaapiFeiEncH264))
+#define GST_IS_VAAPI_FEI_ENC_H264(encoder) \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((encoder), GST_TYPE_VAAPI_FEI_ENC_H264))
+
 typedef struct _GstVaapiFeiEncH264 GstVaapiFeiEncH264;
+typedef struct _GstVaapiFeiEncH264Class GstVaapiFeiEncH264Class;
 
 /**
  * GstVaapiFeiEncH264Prop:
@@ -80,6 +87,9 @@ typedef enum
   GST_VAAPI_FEI_H264_ENC_PROP_MULTI_PRED_L1 = -26,
   GST_VAAPI_FEI_H264_ENC_PROP_ENABLE_STATS_OUT = -27,
 } GstVaapiFeiEncH264Prop;
+
+GType
+gst_vaapi_feienc_h264_get_type (void) G_GNUC_CONST;
 
 GstVaapiEncoder *
 gst_vaapi_feienc_h264_new (GstVaapiDisplay * display);


### PR DESCRIPTION
Replace all gstvaapiobject in vaapi encoders with standard gstobject.
Let the gstobject common logic to handle all the init and finalize
works. But the property install/set/get still use the old way, need
to be improved later.