### PR TITLE
vaapipostproc: advertise crop meta is handled

### DIFF
--- a/gst/vaapi/gstvaapipostproc.h
+++ b/gst/vaapi/gstvaapipostproc.h
@@ -175,11 +175,13 @@ struct _GstVaapiPostproc
   gfloat contrast;
 
   gboolean skintone_enhance;
+  gboolean forward_crop;
 
   guint get_va_surfaces:1;
   guint has_vpp:1;
   guint use_vpp:1;
   guint keep_aspect:1;
+  guint force_crop:1;
 
   /* color balance's channel list */
   GList *cb_channels;


### PR DESCRIPTION
Advertise to upstream that vaapipostproc can handle
crop meta.

When used in conjunction with videocrop plugin, the
videocrop plugin will only do in-place transform on the
crop meta when vaapipostproc advertises the ability to
handle it.  This allows vaapipostproc to apply the crop
meta on the output buffer using vaapi acceleration.
Without this advertisement, the videocrop plugin will
crop the output buffer directly via software methods,
which is not what we desire.

Add force-vpp-crop property.  When disabled (default),
vaapipostproc will not apply the crop meta if downstream
advertises crop meta handling; vaapipostproc will just
forward the crop meta to downstream.  If crop meta is
not advertised by downstream, then vaapipostproc will
apply the crop meta.  If force-vpp-crop is enabled,
then vaapipostproc will always apply the crop meta
regardless of downstream advertisement.

Examples:

 gst-launch-1.0 videotestsrc \
  ! videocrop left=10 \
  ! vaapipostproc \
  ! vaapisink

 gst-launch-1.0 videotestsrc \
  ! videocrop left=10 \
  ! vaapipostproc force-vpp-crop=true \
  ! vaapisink