### PR TITLE
libs: h264decoder: do not return error for unhandled NAL unit.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
@@ -4312,9 +4312,22 @@ decode_unit (GstVaapiDecoderH264 * decoder, GstVaapiDecoderUnit * unit)
     case GST_H264_NAL_SEI:
       status = decode_sei (decoder, unit);
       break;
+    case GST_H264_NAL_SLICE_DPA:
+    case GST_H264_NAL_SLICE_DPB:
+    case GST_H264_NAL_SLICE_DPC:
+    case GST_H264_NAL_AU_DELIMITER:
+    case GST_H264_NAL_FILLER_DATA:
+    case GST_H264_NAL_SPS_EXT:
+    case GST_H264_NAL_PREFIX_UNIT:
+    case GST_H264_NAL_DEPTH_SPS:
+    case GST_H264_NAL_SLICE_AUX:
+    case GST_H264_NAL_SLICE_DEPTH:
+      GST_DEBUG ("unsupported NAL unit type %d, just skip", pi->nalu.type);
+      status = GST_VAAPI_DECODER_STATUS_SUCCESS;
+      break;
     default:
-      GST_WARNING ("unsupported NAL unit type %d", pi->nalu.type);
-      status = GST_VAAPI_DECODER_STATUS_ERROR_BITSTREAM_PARSER;
+      GST_WARNING ("unknown NAL unit type id %d, skip", pi->nalu.type);
+      status = GST_VAAPI_DECODER_STATUS_SUCCESS;
       break;
   }
   return status;


### PR DESCRIPTION
Some streams have error data introducing unknown NAL type. There are
also kinds of NAL types we do not want to handle. The old manner will
set a decoder error when encounter this, which cause a latent crash bug.
The decoder may successfully decode the picture and insert it into DPB.
But there are error NAL units after the AU which cause the post unit error
and make that frame dropped. The later output of the picture still want
to ref that frame and crash.
No need to set decoder error when can not recognize or handle the NAL
unit, just skip it and continue.

Fix: #191