### PR TITLE
libs: replace gstvaapiobject using GstMiniObject.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicodedbuffer_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapicodedbuffer_priv.h
@@ -33,8 +33,6 @@ G_BEGIN_DECLS
 #define GST_VAAPI_CODED_BUFFER_CAST(obj) \
     ((GstVaapiCodedBuffer *)(obj))
 
-typedef struct _GstVaapiCodedBufferClass        GstVaapiCodedBufferClass;
-
 /**
  * GstVaapiCodedBuffer:
  *
@@ -42,22 +40,13 @@ typedef struct _GstVaapiCodedBufferClass        GstVaapiCodedBufferClass;
  */
 struct _GstVaapiCodedBuffer
 {
-  /*< private >*/
-  GstVaapiObject parent_instance;
+  /*< common header >*/
+  GstMiniObject mini_object;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
 
   GstVaapiContext      *context;
   VACodedBufferSegment *segment_list;
-};
-
-/**
- * GstVaapiCodedBufferClass:
- *
- * A VA coded buffer object wrapper class.
- */
-struct _GstVaapiCodedBufferClass
-{
-  /*< private >*/
-  GstVaapiObjectClass parent_class;
 };
 
 G_GNUC_INTERNAL

--- a/gst-libs/gst/vaapi/gstvaapicontext.h
+++ b/gst-libs/gst/vaapi/gstvaapicontext.h
@@ -41,7 +41,6 @@ G_BEGIN_DECLS
 typedef struct _GstVaapiConfigInfoEncoder GstVaapiConfigInfoEncoder;
 typedef struct _GstVaapiContextInfo GstVaapiContextInfo;
 typedef struct _GstVaapiContext GstVaapiContext;
-typedef struct _GstVaapiContextClass GstVaapiContextClass;
 
 /**
  * GstVaapiContextUsage:
@@ -104,8 +103,10 @@ struct _GstVaapiContextInfo
  */
 struct _GstVaapiContext
 {
-  /*< private >*/
-  GstVaapiObject parent_instance;
+  /*< common header >*/
+  GstMiniObject mini_object;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
 
   GstVaapiContextInfo info;
   VAProfile va_profile;
@@ -117,17 +118,6 @@ struct _GstVaapiContext
   guint overlay_id;
   gboolean reset_on_resize;
   GstVaapiConfigSurfaceAttributes *attribs;
-};
-
-/**
- * GstVaapiContextClass:
- *
- * A VA context wrapper class.
- */
-struct _GstVaapiContextClass
-{
-  /*< private >*/
-  GstVaapiObjectClass parent_class;
 };
 
 G_GNUC_INTERNAL

--- a/gst-libs/gst/vaapi/gstvaapiimage_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapiimage_priv.h
@@ -30,7 +30,6 @@
 
 G_BEGIN_DECLS
 
-typedef struct _GstVaapiImageClass              GstVaapiImageClass;
 typedef struct _GstVaapiImageRaw                GstVaapiImageRaw;
 
 /**
@@ -39,8 +38,10 @@ typedef struct _GstVaapiImageRaw                GstVaapiImageRaw;
  * A VA image wrapper
  */
 struct _GstVaapiImage {
-    /*< private >*/
-    GstVaapiObject      parent_instance;
+    /*< common header >*/
+    GstMiniObject mini_object;
+    GstVaapiDisplay *display;
+    GstVaapiID object_id;
 
     VAImage             internal_image;
     VAImage             image;
@@ -50,16 +51,6 @@ struct _GstVaapiImage {
     guint               width;
     guint               height;
     guint               is_linear       : 1;
-};
-
-/**
- * GstVaapiImageClass:
- *
- * A VA image wrapper class
- */
-struct _GstVaapiImageClass {
-    /*< private >*/
-    GstVaapiObjectClass parent_class;
 };
 
 /**

--- a/gst-libs/gst/vaapi/gstvaapiobject.c
+++ b/gst-libs/gst/vaapi/gstvaapiobject.c
@@ -26,6 +26,7 @@
  * SECTION:gstvaapiobject
  * @short_description: Base VA object
  */
+#if 0
 
 #include "sysdeps.h"
 #include "gstvaapiobject.h"
@@ -204,3 +205,4 @@ gst_vaapi_object_get_id (GstVaapiObject * object)
 
   return GST_VAAPI_OBJECT_ID (object);
 }
+#endif

--- a/gst-libs/gst/vaapi/gstvaapiobject.h
+++ b/gst-libs/gst/vaapi/gstvaapiobject.h
@@ -35,27 +35,44 @@ G_BEGIN_DECLS
 
 typedef struct _GstVaapiObject GstVaapiObject;
 
-gpointer
-gst_vaapi_object_ref (gpointer object);
+/**
+ * GstVaapiObject:
+ *
+ * All VA object common header.
+ */
+struct _GstVaapiObject
+{
+  GstMiniObject mini_object;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
+};
 
-void
-gst_vaapi_object_unref (gpointer object);
+static inline gpointer
+gst_vaapi_object_ref (gpointer object)
+{
+  return gst_mini_object_ref ((GstMiniObject *) object);
+}
 
-void
-gst_vaapi_object_replace (gpointer old_object_ptr, gpointer new_object);
+static inline void
+gst_vaapi_object_unref (gpointer object)
+{
+  gst_mini_object_unref ((GstMiniObject *) object);
+}
 
-GstVaapiDisplay *
-gst_vaapi_object_get_display (GstVaapiObject * object);
+static inline void
+gst_vaapi_object_replace (gpointer old_object_ptr, gpointer new_object)
+{
+  gst_mini_object_replace ((GstMiniObject **) old_object_ptr,
+      (GstMiniObject *) new_object);
+}
 
-void
-gst_vaapi_object_lock_display (GstVaapiObject * object);
-
-void
-gst_vaapi_object_unlock_display (GstVaapiObject * object);
-
-GstVaapiID
-gst_vaapi_object_get_id (GstVaapiObject * object);
+static inline GstVaapiDisplay *
+gst_vaapi_object_get_display (GstVaapiObject * object)
+{
+  if (object)
+    return object->display;
+  return NULL;
+}
 
 G_END_DECLS
-
 #endif /* GST_VAAPI_OBJECT_H */

--- a/gst-libs/gst/vaapi/gstvaapiobject_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapiobject_priv.h
@@ -31,39 +31,6 @@
 
 G_BEGIN_DECLS
 
-#define GST_VAAPI_OBJECT_CLASS(klass) \
-  ((GstVaapiObjectClass *) (klass))
-#define GST_VAAPI_IS_OBJECT_CLASS(klass) \
-  ((klass) != NULL)
-#define GST_VAAPI_OBJECT_GET_CLASS(object) \
-  GST_VAAPI_OBJECT_CLASS (GST_VAAPI_MINI_OBJECT_GET_CLASS (object))
-
-typedef struct _GstVaapiObjectClass GstVaapiObjectClass;
-typedef void (*GstVaapiObjectInitFunc) (GstVaapiObject * object);
-typedef void (*GstVaapiObjectFinalizeFunc) (GstVaapiObject * object);
-
-#define GST_VAAPI_OBJECT_DEFINE_CLASS_WITH_CODE(TN, t_n, code)  \
-static inline const GstVaapiObjectClass *                       \
-G_PASTE(t_n,_class) (void)                                      \
-{                                                               \
-    static G_PASTE(TN,Class) g_class;                           \
-    static gsize g_class_init = FALSE;                          \
-                                                                \
-    if (g_once_init_enter (&g_class_init)) {                    \
-        GstVaapiObjectClass * const klass =                     \
-            GST_VAAPI_OBJECT_CLASS (&g_class);                  \
-        gst_vaapi_object_class_init (klass, sizeof(TN));        \
-        code;                                                   \
-        klass->finalize = (GstVaapiObjectFinalizeFunc)          \
-            G_PASTE(t_n,_finalize);                             \
-        g_once_init_leave (&g_class_init, TRUE);                \
-    }                                                           \
-    return GST_VAAPI_OBJECT_CLASS (&g_class);                   \
-}
-
-#define GST_VAAPI_OBJECT_DEFINE_CLASS(TN, t_n) \
-  GST_VAAPI_OBJECT_DEFINE_CLASS_WITH_CODE (TN, t_n, /**/)
-
 /**
  * GST_VAAPI_OBJECT_ID:
  * @object: a #GstVaapiObject
@@ -157,41 +124,6 @@ G_PASTE(t_n,_class) (void)                                      \
  */
 #define GST_VAAPI_OBJECT_UNLOCK_DISPLAY(object) \
   GST_VAAPI_DISPLAY_UNLOCK (GST_VAAPI_OBJECT_DISPLAY (object))
-
-/**
- * GstVaapiObject:
- *
- * VA object base.
- */
-struct _GstVaapiObject
-{
-  /*< private >*/
-  GstVaapiMiniObject parent_instance;
-
-  GstVaapiDisplay *display;
-  GstVaapiID object_id;
-};
-
-/**
- * GstVaapiObjectClass:
- *
- * VA object base class.
- */
-struct _GstVaapiObjectClass
-{
-  /*< private >*/
-  GstVaapiMiniObjectClass parent_class;
-
-  GstVaapiObjectInitFunc init;
-  GstVaapiObjectFinalizeFunc finalize;
-};
-
-void
-gst_vaapi_object_class_init (GstVaapiObjectClass * klass, guint size);
-
-gpointer
-gst_vaapi_object_new (const GstVaapiObjectClass * klass,
-    GstVaapiDisplay * display);
 
 G_END_DECLS
 

--- a/gst-libs/gst/vaapi/gstvaapipixmap.h
+++ b/gst-libs/gst/vaapi/gstvaapipixmap.h
@@ -35,7 +35,6 @@ G_BEGIN_DECLS
     ((GstVaapiPixmap *)(obj))
 
 typedef struct _GstVaapiPixmap                  GstVaapiPixmap;
-typedef struct _GstVaapiPixmapClass             GstVaapiPixmapClass;
 
 /**
  * GST_VAAPI_PIXMAP_FORMAT:

--- a/gst-libs/gst/vaapi/gstvaapipixmap_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapipixmap_priv.h
@@ -27,12 +27,6 @@
 
 G_BEGIN_DECLS
 
-#define GST_VAAPI_PIXMAP_CLASS(klass) \
-    ((GstVaapiPixmapClass *)(klass))
-
-#define GST_VAAPI_PIXMAP_GET_CLASS(obj) \
-    GST_VAAPI_PIXMAP_CLASS(GST_VAAPI_OBJECT_GET_CLASS(obj))
-
 /**
  * GST_VAAPI_PIXMAP_FORMAT:
  * @pixmap: a #GstVaapiPixmap
@@ -70,43 +64,39 @@ typedef gboolean  (*GstVaapiPixmapRenderFunc)  (GstVaapiPixmap *pixmap,
 
 /**
  * GstVaapiPixmap:
+ * @create: virtual function to create a pixmap with width and height
+ * @render: virtual function to render a #GstVaapiSurface into a pixmap
  *
  * Base class for system-dependent pixmaps.
  */
 struct _GstVaapiPixmap {
-    /*< private >*/
-    GstVaapiObject parent_instance;
+    /*< common header >*/
+    GstMiniObject mini_object;
+    GstVaapiDisplay *display;
+    GstVaapiID object_id;
 
     /*< protected >*/
+    GstVaapiPixmapCreateFunc    create;
+    GstVaapiPixmapRenderFunc    render;
     GstVideoFormat      format;
     guint               width;
     guint               height;
     guint               use_foreign_pixmap      : 1;
 };
 
-/**
- * GstVaapiPixmapClass:
- * @create: virtual function to create a pixmap with width and height
- * @render: virtual function to render a #GstVaapiSurface into a pixmap
- *
- * Base class for system-dependent pixmaps.
- */
-struct _GstVaapiPixmapClass {
-    /*< private >*/
-    GstVaapiObjectClass parent_class;
-
-    /*< protected >*/
-    GstVaapiPixmapCreateFunc    create;
-    GstVaapiPixmapRenderFunc    render;
-};
-
+G_GNUC_INTERNAL
 GstVaapiPixmap *
-gst_vaapi_pixmap_new(const GstVaapiPixmapClass *pixmap_class,
-    GstVaapiDisplay *display, GstVideoFormat format, guint width, guint height);
+gst_vaapi_pixmap_init (GstVaapiPixmap * pixmap,
+    GstVaapiPixmapCreateFunc create,
+    GstVaapiPixmapRenderFunc render,
+    GstVaapiDisplay * display, GstVideoFormat format, guint width, guint height);
 
+G_GNUC_INTERNAL
 GstVaapiPixmap *
-gst_vaapi_pixmap_new_from_native(const GstVaapiPixmapClass *pixmap_class,
-    GstVaapiDisplay *display, gpointer native_pixmap);
+gst_vaapi_pixmap_init_from_native (GstVaapiPixmap * pixmap,
+    GstVaapiPixmapCreateFunc create,
+    GstVaapiPixmapRenderFunc render,
+    GstVaapiDisplay * display, gpointer native_pixmap);
 
 G_END_DECLS
 

--- a/gst-libs/gst/vaapi/gstvaapisurface_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapisurface_priv.h
@@ -29,8 +29,6 @@
 
 G_BEGIN_DECLS
 
-typedef struct _GstVaapiSurfaceClass            GstVaapiSurfaceClass;
-
 /**
  * GstVaapiSurface:
  *
@@ -38,8 +36,10 @@ typedef struct _GstVaapiSurfaceClass            GstVaapiSurfaceClass;
  */
 struct _GstVaapiSurface
 {
-  /*< private >*/
-  GstVaapiObject parent_instance;
+  /*< common header >*/
+  GstMiniObject mini_object;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
 
   GstVaapiBufferProxy *extbuf_proxy;
   GstVideoFormat format;
@@ -47,17 +47,6 @@ struct _GstVaapiSurface
   guint height;
   GstVaapiChromaType chroma_type;
   GPtrArray *subpictures;
-};
-
-/**
- * GstVaapiSurfaceClass:
- *
- * A VA surface wrapper class.
- */
-struct _GstVaapiSurfaceClass
-{
-  /*< private >*/
-  GstVaapiObjectClass parent_class;
 };
 
 /**

--- a/gst-libs/gst/vaapi/gstvaapitexture_priv.h
+++ b/gst-libs/gst/vaapi/gstvaapitexture_priv.h
@@ -29,12 +29,6 @@
 
 G_BEGIN_DECLS
 
-#define GST_VAAPI_TEXTURE_CLASS(klass) \
-  ((GstVaapiTextureClass *)(klass))
-
-#define GST_VAAPI_TEXTURE_GET_CLASS(obj) \
-  GST_VAAPI_TEXTURE_CLASS (GST_VAAPI_OBJECT_GET_CLASS (obj))
-
 /**
  * GST_VAAPI_TEXTURE_ID:
  * @texture: a #GstVaapiTexture
@@ -96,18 +90,20 @@ typedef gboolean (*GstVaapiTexturePutSurfaceFunc) (GstVaapiTexture * texture,
     GstVaapiSurface * surface, const GstVaapiRectangle * crop_rect,
     guint flags);
 
-typedef struct _GstVaapiTextureClass GstVaapiTextureClass;
-
 /**
  * GstVaapiTexture:
  *
  * Base class for API-dependent textures.
  */
 struct _GstVaapiTexture {
-  /*< private >*/
-  GstVaapiObject parent_instance;
+  /*< common header >*/
+  GstMiniObject mini_object;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
 
   /*< protected >*/
+  GstVaapiTextureAllocateFunc allocate;
+  GstVaapiTexturePutSurfaceFunc put_surface;
   guint gl_target;
   guint gl_format;
   guint width;
@@ -115,23 +111,10 @@ struct _GstVaapiTexture {
   guint is_wrapped:1;
 };
 
-/**
- * GstVaapiTextureClass:
- * @put_surface: virtual function to render a #GstVaapiSurface into a texture
- *
- * Base class for API-dependent textures.
- */
-struct _GstVaapiTextureClass {
-  /*< private >*/
-  GstVaapiObjectClass parent_class;
-
-  /*< protected >*/
-  GstVaapiTextureAllocateFunc allocate;
-  GstVaapiTexturePutSurfaceFunc put_surface;
-};
-
 GstVaapiTexture *
-gst_vaapi_texture_new_internal (const GstVaapiTextureClass * klass,
+gst_vaapi_texture_init_internal (GstVaapiTexture * texture,
+    GstVaapiTextureAllocateFunc allocate,
+    GstVaapiTexturePutSurfaceFunc put_surface,
     GstVaapiDisplay * display, GstVaapiID id, guint target, guint format,
     guint width, guint height);
 


### PR DESCRIPTION
The GstVaapiMiniObject is obsolete and need to use GstMiniObject to
replace it. The gstvaapiobject is the base class of many useful vaapi
objects, such as image, surface and texture. we still define a common
class as the first part of all these objects and use GstMiniObject to
replace all GstVaapiMiniObject inside it, which can make all the
objects follow standard gst framework and make the code clean.