### PR TITLE
libs: change GstVaapiContext's base class

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicodedbuffer.c
+++ b/gst-libs/gst/vaapi/gstvaapicodedbuffer.c
@@ -40,8 +40,7 @@ coded_buffer_create (GstVaapiCodedBuffer * buf, guint buf_size,
 
   GST_VAAPI_DISPLAY_LOCK (display);
   success = vaapi_create_buffer (GST_VAAPI_DISPLAY_VADISPLAY (display),
-      GST_VAAPI_OBJECT_ID (context), VAEncCodedBufferType, buf_size, NULL,
-      &buf_id, NULL);
+      context->object_id, VAEncCodedBufferType, buf_size, NULL, &buf_id, NULL);
   GST_VAAPI_DISPLAY_UNLOCK (display);
   if (!success)
     return FALSE;
@@ -117,7 +116,7 @@ gst_vaapi_coded_buffer_new (GstVaapiContext * context, guint buf_size)
   g_return_val_if_fail (context != NULL, NULL);
   g_return_val_if_fail (buf_size > 0, NULL);
 
-  display = GST_VAAPI_OBJECT_DISPLAY (context);
+  display = context->display;
   g_return_val_if_fail (display != NULL, NULL);
 
   buf = gst_vaapi_object_new (gst_vaapi_coded_buffer_class (), display);

--- a/gst-libs/gst/vaapi/gstvaapicodedbufferpool.c
+++ b/gst-libs/gst/vaapi/gstvaapicodedbufferpool.c
@@ -47,7 +47,7 @@ static void
 coded_buffer_pool_init (GstVaapiCodedBufferPool * pool,
     GstVaapiContext * context, gsize buf_size)
 {
-  pool->context = gst_vaapi_object_ref (context);
+  pool->context = gst_vaapi_context_ref (context);
   pool->buf_size = buf_size;
 }
 
@@ -55,7 +55,8 @@ static void
 coded_buffer_pool_finalize (GstVaapiCodedBufferPool * pool)
 {
   gst_vaapi_video_pool_finalize (GST_VAAPI_VIDEO_POOL (pool));
-  gst_vaapi_object_replace (&pool->context, NULL);
+  gst_vaapi_context_unref (pool->context);
+  pool->context = NULL;
 }
 
 static gpointer
@@ -106,7 +107,7 @@ gst_vaapi_coded_buffer_pool_new (GstVaapiEncoder * encoder, gsize buf_size)
   if (!pool)
     return NULL;
 
-  gst_vaapi_video_pool_init (pool, GST_VAAPI_OBJECT_DISPLAY (context),
+  gst_vaapi_video_pool_init (pool, context->display,
       GST_VAAPI_VIDEO_POOL_OBJECT_TYPE_CODED_BUFFER);
   coded_buffer_pool_init (GST_VAAPI_CODED_BUFFER_POOL (pool),
       context, buf_size);

--- a/gst-libs/gst/vaapi/gstvaapicontext.h
+++ b/gst-libs/gst/vaapi/gstvaapicontext.h
@@ -41,7 +41,6 @@ G_BEGIN_DECLS
 typedef struct _GstVaapiConfigInfoEncoder GstVaapiConfigInfoEncoder;
 typedef struct _GstVaapiContextInfo GstVaapiContextInfo;
 typedef struct _GstVaapiContext GstVaapiContext;
-typedef struct _GstVaapiContextClass GstVaapiContextClass;
 
 /**
  * GstVaapiContextUsage:
@@ -104,9 +103,9 @@ struct _GstVaapiContextInfo
  */
 struct _GstVaapiContext
 {
-  /*< private >*/
-  GstVaapiObject parent_instance;
-
+  gint ref_count;
+  GstVaapiDisplay *display;
+  GstVaapiID object_id;
   GstVaapiContextInfo info;
   VAProfile va_profile;
   VAEntrypoint va_entrypoint;
@@ -117,17 +116,6 @@ struct _GstVaapiContext
   guint overlay_id;
   gboolean reset_on_resize;
   GstVaapiConfigSurfaceAttributes *attribs;
-};
-
-/**
- * GstVaapiContextClass:
- *
- * A VA context wrapper class.
- */
-struct _GstVaapiContextClass
-{
-  /*< private >*/
-  GstVaapiObjectClass parent_class;
 };
 
 G_GNUC_INTERNAL
@@ -165,6 +153,14 @@ G_GNUC_INTERNAL
 gboolean
 gst_vaapi_context_get_surface_attributes (GstVaapiContext * context,
     GstVaapiConfigSurfaceAttributes * out_attribs);
+
+G_GNUC_INTERNAL
+GstVaapiContext *
+gst_vaapi_context_ref (GstVaapiContext * context);
+
+G_GNUC_INTERNAL
+void
+gst_vaapi_context_unref (GstVaapiContext * context);
 
 G_END_DECLS
 

--- a/gst-libs/gst/vaapi/gstvaapidecoder.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder.c
@@ -483,7 +483,8 @@ gst_vaapi_decoder_finalize (GObject * object)
     decoder->frames = NULL;
   }
 
-  gst_vaapi_object_replace (&decoder->context, NULL);
+  gst_vaapi_context_unref (decoder->context);
+  decoder->context = NULL;
   decoder->va_context = VA_INVALID_ID;
 
   gst_vaapi_display_replace (&decoder->display, NULL);

--- a/gst-libs/gst/vaapi/gstvaapiencoder.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.c
@@ -1372,7 +1372,8 @@ gst_vaapi_encoder_finalize (GObject * object)
 {
   GstVaapiEncoder *encoder = GST_VAAPI_ENCODER (object);
 
-  gst_vaapi_object_replace (&encoder->context, NULL);
+  gst_vaapi_context_unref (encoder->context);
+  encoder->context = NULL;
   gst_vaapi_display_replace (&encoder->display, NULL);
   encoder->va_display = NULL;
 
@@ -1512,7 +1513,7 @@ create_test_context_config (GstVaapiEncoder * encoder, GstVaapiProfile profile)
   GstVaapiContext *ctxt;
 
   if (encoder->context)
-    return gst_vaapi_object_ref (encoder->context);
+    return gst_vaapi_context_ref (encoder->context);
 
   /* if there is no profile, let's figure out one */
   if (profile == GST_VAAPI_PROFILE_UNKNOWN)
@@ -1533,7 +1534,7 @@ get_profile_surface_formats (GstVaapiEncoder * encoder, GstVaapiProfile profile)
   if (!ctxt)
     return NULL;
   formats = gst_vaapi_context_get_surface_formats (ctxt);
-  gst_vaapi_object_unref (ctxt);
+  gst_vaapi_context_unref (ctxt);
   return formats;
 }
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
@@ -3796,7 +3796,7 @@ static inline gboolean
 context_get_attribute (GstVaapiContext * context, VAConfigAttribType type,
     guint * out_value_ptr)
 {
-  return gst_vaapi_get_config_attribute (GST_VAAPI_OBJECT_DISPLAY (context),
+  return gst_vaapi_get_config_attribute (context->display,
       context->va_profile, context->va_entrypoint, type, out_value_ptr);
 }
 

--- a/gst-libs/gst/vaapi/gstvaapiprofilecaps.c
+++ b/gst-libs/gst/vaapi/gstvaapiprofilecaps.c
@@ -87,7 +87,7 @@ append_caps_with_context_info (GstVaapiDisplay * display,
     return FALSE;
 
   ret = append_caps (context, structure);
-  gst_vaapi_object_unref (context);
+  gst_vaapi_context_unref (context);
   return ret;
 }
 


### PR DESCRIPTION
The GstVaapiMiniObject is obsolete and need to replace it.
Do not use GstVaapiObject as GstVaapiContext's base class, just use
a simple way to implement it.