### PR TITLE
libs: display: filter out duplicated profiles in get_profiles.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidisplay.c
+++ b/gst-libs/gst/vaapi/gstvaapidisplay.c
@@ -326,7 +326,8 @@ get_profiles (GArray * configs)
 {
   GstVaapiConfig *config;
   GArray *out_profiles;
-  guint i;
+  GstVaapiProfile profile;
+  guint i, j;
 
   if (!configs)
     return NULL;
@@ -337,7 +338,13 @@ get_profiles (GArray * configs)
 
   for (i = 0; i < configs->len; i++) {
     config = &g_array_index (configs, GstVaapiConfig, i);
-    g_array_append_val (out_profiles, config->profile);
+    for (j = 0; j < out_profiles->len; j++) {
+      profile = g_array_index (out_profiles, GstVaapiProfile, j);
+      if (config->profile == profile)
+        break;
+    }
+    if (j >= out_profiles->len)
+      g_array_append_val (out_profiles, config->profile);
   }
   return out_profiles;
 }


### PR DESCRIPTION
The GstVaapiConfig contain profile and entrypoint pairs. So some
profiles may appear more than once in the array.