### PR TITLE
libs: video-format: change GST_VIDEO_FORMAT_AYUV to VUYA.

### DIFF
--- a/gst-libs/gst/vaapi/video-format.c
+++ b/gst-libs/gst/vaapi/video-format.c
@@ -445,7 +445,7 @@ gst_vaapi_video_format_from_chroma (guint chroma_type)
     case GST_VAAPI_CHROMA_TYPE_YUV420_10BPP:
       return GST_VIDEO_FORMAT_P010_10LE;
     case GST_VAAPI_CHROMA_TYPE_YUV444:
-      return GST_VIDEO_FORMAT_AYUV;
+      return GST_VIDEO_FORMAT_VUYA;
     case GST_VAAPI_CHROMA_TYPE_YUV422_10BPP:
       return GST_VIDEO_FORMAT_Y210;
     case GST_VAAPI_CHROMA_TYPE_YUV444_10BPP:

--- a/tests/internal/test-windows.c
+++ b/tests/internal/test-windows.c
@@ -62,7 +62,7 @@ create_test_surface (GstVaapiDisplay * display, guint width, guint height)
     GST_VIDEO_FORMAT_NV12,
     GST_VIDEO_FORMAT_YV12,
     GST_VIDEO_FORMAT_I420,
-    GST_VIDEO_FORMAT_AYUV,
+    GST_VIDEO_FORMAT_VUYA,
     GST_VIDEO_FORMAT_ARGB,
     GST_VIDEO_FORMAT_BGRA,
     GST_VIDEO_FORMAT_RGBA,


### PR DESCRIPTION
We only support VUYA format in gst vaapi now, need to correct
the mapping.