### PR TITLE
libs: decoder: context: remove surfaces binding from context.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicontext.c
+++ b/gst-libs/gst/vaapi/gstvaapicontext.c
@@ -139,6 +139,38 @@ context_ensure_surfaces (GstVaapiContext * context)
 }
 
 static gboolean
+context_create_surface_pool (GstVaapiContext * context)
+{
+  const GstVaapiContextInfo *const cip = &context->info;
+  GstVaapiDisplay *const display = GST_VAAPI_OBJECT_DISPLAY (context);
+  guint i;
+
+  if (!ensure_attributes (context))
+    return FALSE;
+
+  /* check whether chroma_type is compitable */
+  for (i = 0; i < context->attribs->formats->len; i++) {
+    GstVideoFormat format =
+        g_array_index (context->attribs->formats, GstVideoFormat, i);
+    if (format == gst_vaapi_video_format_from_chroma (cip->chroma_type)) {
+      context->surfaces_pool =
+          gst_vaapi_surface_pool_new_with_chroma_type (display,
+          cip->chroma_type, cip->width, cip->height);
+      break;
+    }
+  }
+
+  if (!context->surfaces_pool) {
+    GST_INFO ("Can not create a compitable surfaces_pool for chroma_type %d",
+        cip->chroma_type);
+    return FALSE;
+  }
+
+  gst_vaapi_video_pool_set_capacity (context->surfaces_pool, 0);
+  return TRUE;
+}
+
+static gboolean
 context_create_surfaces (GstVaapiContext * context)
 {
   const GstVaapiContextInfo *const cip = &context->info;
@@ -176,6 +208,30 @@ context_create (GstVaapiContext * context)
   gboolean success = FALSE;
   guint i;
 
+#if SUPPORT_SURFACELESS_CONTEXT
+  if (cip->usage == GST_VAAPI_CONTEXT_USAGE_DECODE) {
+    /* try surfaceless context creation, if fail, fallback */
+    if (!context->surfaces_pool)
+      context_create_surface_pool (context);
+
+    if (context->surfaces_pool) {
+      GST_VAAPI_DISPLAY_LOCK (display);
+      status = vaCreateContext (GST_VAAPI_DISPLAY_VADISPLAY (display),
+          context->va_config, cip->width, cip->height, VA_PROGRESSIVE,
+          NULL, 0, &context_id);
+      GST_VAAPI_DISPLAY_UNLOCK (display);
+      if (vaapi_check_status (status, "vaCreateContext()")) {
+        GST_DEBUG ("Succeed to create context 0x%08x without surface",
+            context_id);
+        GST_VAAPI_OBJECT_ID (context) = context_id;
+        success = TRUE;
+        context->surfaces = NULL;
+        goto cleanup;
+      }
+    }
+  }
+#endif
+
   if (!context->surfaces && !context_create_surfaces (context))
     goto cleanup;
 
@@ -192,6 +248,7 @@ context_create (GstVaapiContext * context)
     surface_id = GST_VAAPI_OBJECT_ID (surface);
     g_array_append_val (surfaces, surface_id);
   }
+
   g_assert (surfaces->len == context->surfaces->len);
 
   GST_VAAPI_DISPLAY_LOCK (display);
@@ -391,6 +448,8 @@ gst_vaapi_context_init (GstVaapiContext * context,
   context->reset_on_resize = TRUE;
 
   context->attribs = NULL;
+  context->surfaces = NULL;
+  context->surfaces_pool = NULL;
 }
 
 static void
@@ -442,8 +501,7 @@ gst_vaapi_context_new (GstVaapiDisplay * display,
   if (!context_create (context))
     goto error;
 
-done:
-  return context;
+done:return context;
 
   /* ERRORS */
 error:
@@ -472,6 +530,8 @@ gst_vaapi_context_reset (GstVaapiContext * context,
   gboolean reset_surfaces = FALSE, reset_config = FALSE;
   gboolean grow_surfaces = FALSE;
   GstVaapiChromaType chroma_type;
+  gboolean is_surfaceless = (context->surfaces == NULL
+      && new_cip->usage == GST_VAAPI_CONTEXT_USAGE_DECODE);
 
   chroma_type = new_cip->chroma_type ? new_cip->chroma_type :
       DEFAULT_CHROMA_TYPE;
@@ -517,9 +577,16 @@ gst_vaapi_context_reset (GstVaapiContext * context,
 
   if (reset_config && !(config_create (context) && context_create (context)))
     return FALSE;
-  if (reset_surfaces && !context_create_surfaces (context))
-    return FALSE;
-  else if (grow_surfaces && !context_ensure_surfaces (context))
+  if (reset_surfaces) {
+    if (is_surfaceless && context_create_surface_pool (context)) {
+      context->surfaces = NULL;
+      return TRUE;
+    }
+
+    if (!context_create_surfaces (context))
+      return FALSE;
+  } else if (grow_surfaces && !is_surfaceless
+      && !context_ensure_surfaces (context))
     return FALSE;
   return TRUE;
 }
@@ -571,14 +638,21 @@ gst_vaapi_context_get_surface_proxy (GstVaapiContext * context)
  *
  * Retrieves the number of free surfaces left in the pool.
  *
- * Return value: the number of free surfaces available in the pool
+ * Return value: the number of free surfaces available in the pool,
+ *  for surfaceless context, we just return -1.
  */
-guint
+gint
 gst_vaapi_context_get_surface_count (GstVaapiContext * context)
 {
   g_return_val_if_fail (context != NULL, 0);
 
-  return gst_vaapi_video_pool_get_size (context->surfaces_pool);
+  /* For surfaceless context */
+  if (context->surfaces == NULL) {
+    g_assert (gst_vaapi_video_pool_get_capacity (context->surfaces_pool) == 0);
+    return -1;
+  }
+
+  return (gint) gst_vaapi_video_pool_get_size (context->surfaces_pool);
 }
 
 /**

--- a/gst-libs/gst/vaapi/gstvaapicontext.h
+++ b/gst-libs/gst/vaapi/gstvaapicontext.h
@@ -149,7 +149,7 @@ GstVaapiSurfaceProxy *
 gst_vaapi_context_get_surface_proxy (GstVaapiContext * context);
 
 G_GNUC_INTERNAL
-guint
+gint
 gst_vaapi_context_get_surface_count (GstVaapiContext * context);
 
 G_GNUC_INTERNAL

--- a/gst-libs/gst/vaapi/gstvaapidecoder.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder.c
@@ -1002,8 +1002,11 @@ gst_vaapi_decoder_push_frame (GstVaapiDecoder * decoder,
 GstVaapiDecoderStatus
 gst_vaapi_decoder_check_status (GstVaapiDecoder * decoder)
 {
+  /* Check whether there are still surfaces left in context. For
+     the context created without surfaces, always get -1, and
+     we do not care about this. */
   if (decoder->context &&
-      gst_vaapi_context_get_surface_count (decoder->context) < 1)
+      gst_vaapi_context_get_surface_count (decoder->context) == 0)
     return GST_VAAPI_DECODER_STATUS_ERROR_NO_SURFACE;
   return GST_VAAPI_DECODER_STATUS_SUCCESS;
 }

--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,7 @@ cdata.set10('HAVE_XKBLIB', cc.has_header('X11/XKBlib.h', dependencies: x11_dep))
 cdata.set10('HAVE_XRANDR', xrandr_dep.found())
 cdata.set10('HAVE_XRENDER', xrender_dep.found())
 cdata.set10('USE_GST_GL_HELPERS', gstgl_dep.found())
+cdata.set10('SUPPORT_SURFACELESS_CONTEXT', get_option('surfaceless_context'))
 cdata.set('USE_GLES_VERSION_MASK', GLES_VERSION_MASK)
 
 api_version = '1.0'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,8 @@ option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'aut
 option('with_glx', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_wayland', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_egl', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
+option('surfaceless_context', type : 'boolean', value : true,
+       description : 'support create context without surface pre-allocation')
 
 # Common feature options
 option('examples', type : 'feature', value : 'auto', yield : true)


### PR DESCRIPTION
The vaCreateContext do not need to specify the surfaces for the
context creation now. So we do not need to bind any surface to the
context anymore. Surfaces should be the resource belong to display
and just be used in encoder/decoder context.

The previous manner has big limitation for decoder. The context's
surface number is decided by dpb size. All the surfaces in dpb will
be attached to a gstbuffer and be pushed to down stream, and the
decoder need to wait down stream free the surface and go on if not
enough surface available. For more and more use cases, this causes
deadlock. For example,

gst-launch-1.0 filesrc location=a.h264 ! h264parse ! vaapih264dec
! x264enc ! filesink location=./output.h264

will cause deadlock and make the whole pipeline hang.
the x264enc encoder need to cache more than dpb size surfaces.

The best solution is seperating the surfaces number and the dpb size.
dpb and dpb size shoule be virtual concepts maintained by the decoder.
And let the surfaces_pool in context maintain the re-use of all surfaces.

For encoder, the situation is better, all the surfaces are just used
as reference frame and no need to be pushed to down stream. We can
just reserve and set the capacity of the surfaces_pool to meet the
request.

We add a compilation option 'surfaceless_context' to control whether
to enable this feature. And even enable it, if the context creation
without surface fails, we still fallback to the old manner.
This option just work for decoder, for encoder, we always pre-allocate
all surfaces for the context.