### PR TITLE
libs: decoder: context: remove surfaces binding from context.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicontext.h
+++ b/gst-libs/gst/vaapi/gstvaapicontext.h
@@ -149,7 +149,7 @@ GstVaapiSurfaceProxy *
 gst_vaapi_context_get_surface_proxy (GstVaapiContext * context);
 
 G_GNUC_INTERNAL
-guint
+gint
 gst_vaapi_context_get_surface_count (GstVaapiContext * context);
 
 G_GNUC_INTERNAL

--- a/gst-libs/gst/vaapi/gstvaapidecoder.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder.c
@@ -1002,8 +1002,11 @@ gst_vaapi_decoder_push_frame (GstVaapiDecoder * decoder,
 GstVaapiDecoderStatus
 gst_vaapi_decoder_check_status (GstVaapiDecoder * decoder)
 {
+  /* Check whether there are still surfaces left in context. For
+     the context created without surfaces, always get -1, and
+     we do not care about this. */
   if (decoder->context &&
-      gst_vaapi_context_get_surface_count (decoder->context) < 1)
+      gst_vaapi_context_get_surface_count (decoder->context) == 0)
     return GST_VAAPI_DECODER_STATUS_ERROR_NO_SURFACE;
   return GST_VAAPI_DECODER_STATUS_SUCCESS;
 }

--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,7 @@ cdata.set10('HAVE_XKBLIB', cc.has_header('X11/XKBlib.h', dependencies: x11_dep))
 cdata.set10('HAVE_XRANDR', xrandr_dep.found())
 cdata.set10('HAVE_XRENDER', xrender_dep.found())
 cdata.set10('USE_GST_GL_HELPERS', gstgl_dep.found())
+cdata.set10('SUPPORT_SURFACELESS_CONTEXT', get_option('surfaceless_context'))
 cdata.set('USE_GLES_VERSION_MASK', GLES_VERSION_MASK)
 
 api_version = '1.0'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,8 @@ option('with_x11', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'aut
 option('with_glx', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_wayland', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
 option('with_egl', type : 'combo', choices : ['yes', 'no', 'auto'], value : 'auto')
+option('surfaceless_context', type : 'boolean', value : true,
+       description : 'support create context without surface pre-allocation')
 
 # Common feature options
 option('examples', type : 'feature', value : 'auto', yield : true)


### PR DESCRIPTION
The vaCreateContext do not need to specify the surfaces for the
context creation now. So we do not need to bind any surface to the
context anymore. Surfaces should be the resource belong to display
and just be used in encoder/decoder context.

The previous manner has big limitation for decoder. The context's
surface number is decided by dpb size. All the surfaces in dpb will
be attached to a gstbuffer and be pushed to down stream, and the
decoder need to wait down stream free the surface and go on if not
enough surface available. For more and more use cases, this causes
deadlock. For example,

gst-launch-1.0 filesrc location=a.h264 ! h264parse ! vaapih264dec
! x264enc ! filesink location=./output.h264

will cause deadlock and make the whole pipeline hang.
the x264enc encoder need to cache more than dpb size surfaces.

The best solution is seperating the surfaces number and the dpb size.
dpb and dpb size shoule be virtual concepts maintained by the decoder.
And let the surfaces_pool in context maintain the re-use of all surfaces.

For encoder, the situation is better, all the surfaces are just used
as reference frame and no need to be pushed to down stream. We can
just reserve and set the capacity of the surfaces_pool to meet the
request.

We add a compilation option 'surfaceless_context' to control whether
to enable this feature. And even enable it, if the context creation
without surface fails, we still fallback to the old manner.
This option just work for decoder, for encoder, we always pre-allocate
all surfaces for the context.

Fix: #147
Fix: #88