### PR TITLE
libs: postproc: Modify src/sink template raw formats

### DIFF
--- a/gst/vaapi/gstvaapipostproc.c
+++ b/gst/vaapi/gstvaapipostproc.c
@@ -61,7 +61,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_debug_vaapipostproc);
 static const char gst_vaapipostproc_sink_caps_str[] =
   GST_VAAPI_MAKE_SURFACE_CAPS ", "
   GST_CAPS_INTERLACED_MODES "; "
-  GST_VIDEO_CAPS_MAKE (GST_VIDEO_FORMATS_ALL) ", "
+  GST_VIDEO_CAPS_MAKE (GST_VAAPI_FORMATS_ALL) ", "
    GST_CAPS_INTERLACED_MODES;
 /* *INDENT-ON* */
 
@@ -72,7 +72,7 @@ static const char gst_vaapipostproc_src_caps_str[] =
 #if (USE_GLX || USE_EGL)
   GST_VAAPI_MAKE_GLTEXUPLOAD_CAPS "; "
 #endif
-  GST_VIDEO_CAPS_MAKE (GST_VIDEO_FORMATS_ALL) ", "
+  GST_VIDEO_CAPS_MAKE (GST_VAAPI_FORMATS_ALL) ", "
   GST_CAPS_INTERLACED_MODES "; "
   GST_VAAPI_MAKE_DMABUF_CAPS;
 /* *INDENT-ON* */


### PR DESCRIPTION
We need to provide more precise template caps for postproc's src
and sink pads. The GST_VIDEO_FORMATS_ALL make all video formats
available which are really superfluous.