### PR TITLE
libs: encoder: Set entrypoint based on tune automatically.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidisplay.c
+++ b/gst-libs/gst/vaapi/gstvaapidisplay.c
@@ -527,6 +527,9 @@ ensure_profiles (GstVaapiDisplay * display)
         case GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_FEI:
           g_array_append_val (priv->encoders, config);
           break;
+        default:
+          GST_INFO ("get one invalid entrypoint for profile %s",
+              string_of_VAProfile (profiles[i]));
       }
     }
   }

--- a/gst-libs/gst/vaapi/gstvaapiencoder.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.c
@@ -716,18 +716,9 @@ static void
 init_context_info (GstVaapiEncoder * encoder, GstVaapiContextInfo * cip,
     GstVaapiProfile profile)
 {
-  const GstVaapiEncoderClassData *const cdata =
-      GST_VAAPI_ENCODER_GET_CLASS (encoder)->class_data;
-
   cip->usage = GST_VAAPI_CONTEXT_USAGE_ENCODE;
   cip->profile = profile;
-  if (cdata->codec == GST_VAAPI_CODEC_JPEG) {
-    cip->entrypoint = GST_VAAPI_ENTRYPOINT_PICTURE_ENCODE;
-  } else {
-    if (cip->entrypoint != GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP &&
-        cip->entrypoint != GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_FEI)
-      cip->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
-  }
+  cip->entrypoint = gst_vaapi_encoder_get_entrypoint (encoder);
   cip->chroma_type = get_default_chroma_type (encoder, cip);
   cip->width = 0;
   cip->height = 0;
@@ -1503,8 +1494,12 @@ get_profile_surface_formats (GstVaapiEncoder * encoder, GstVaapiProfile profile)
   GArray *formats;
 
   ctxt = create_test_context_config (encoder, profile);
-  if (!ctxt)
+  if (!ctxt) {
+    GST_WARNING ("failed to create test context for profile %s %s",
+        gst_vaapi_profile_get_media_type_name (profile),
+        gst_vaapi_profile_get_name (profile));
     return NULL;
+  }
   formats = gst_vaapi_context_get_surface_formats (ctxt);
   gst_vaapi_object_unref (ctxt);
   return formats;
@@ -1681,6 +1676,34 @@ gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder)
   g_return_val_if_fail (encoder, GST_VAAPI_PROFILE_UNKNOWN);
 
   return encoder->profile;
+}
+
+/* Get the entrypoint based on the tune option. */
+GstVaapiEntrypoint
+gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder)
+{
+  g_return_val_if_fail (encoder, GST_VAAPI_ENTRYPOINT_INVALID);
+  g_return_val_if_fail (encoder->profile, GST_VAAPI_ENTRYPOINT_INVALID);
+
+  if (encoder->profile == GST_VAAPI_PROFILE_JPEG_BASELINE)
+    return GST_VAAPI_ENTRYPOINT_PICTURE_ENCODE;
+
+  if (GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER) {
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            encoder->profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  } else {
+    /* If not set, choose the available one */
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            encoder->profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
+
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            encoder->profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  }
+
+  return GST_VAAPI_ENTRYPOINT_INVALID;
 }
 
 /** Returns a GType for the #GstVaapiEncoderTune set */

--- a/gst-libs/gst/vaapi/gstvaapiencoder.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.h
@@ -187,6 +187,9 @@ gst_vaapi_encoder_get_surface_formats (GstVaapiEncoder * encoder,
 GstVaapiProfile
 gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder);
 
+GstVaapiEntrypoint
+gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder);
+
 G_END_DECLS
 
 #endif /* GST_VAAPI_ENCODER_H */

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
@@ -1301,14 +1301,6 @@ ensure_tuning (GstVaapiEncoderH264 * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2736,6 +2728,13 @@ ensure_profile_and_level (GstVaapiEncoderH264 * encoder)
     GST_WARNING ("Failed to set some of the tuning option as expected! ");
 
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
+  /* If set low-power encode entry point and hardware doesn't have
+   * support, it will fail in ensure_hw_profile() in later stage. */
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder));
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
   /* Check HW constraints */

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
@@ -1280,14 +1280,6 @@ ensure_tuning (GstVaapiEncoderH264Fei * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2623,6 +2615,11 @@ ensure_profile_and_level (GstVaapiEncoderH264Fei * encoder)
 
   if (!ensure_tuning (encoder))
     GST_WARNING ("Failed to set some of the tuning option as expected! ");
+
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder));
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
@@ -1082,10 +1082,6 @@ ensure_tuning (GstVaapiEncoderH265 * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2037,6 +2033,11 @@ ensure_profile_tier_level (GstVaapiEncoderH265 * encoder)
   ensure_tuning (encoder);
 
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder));
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
   /* Check HW constraints */

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
@@ -526,8 +526,10 @@ gst_vaapi_encoder_vp9_reconfigure (GstVaapiEncoder * base_encoder)
   if (status != GST_VAAPI_ENCODER_STATUS_SUCCESS)
     return status;
 
-  if (GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER)
-    encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  encoder->entrypoint = gst_vaapi_encoder_get_entrypoint (base_encoder);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
   ensure_control_rate_params (encoder);
   return set_context_info (base_encoder);
 }

--- a/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
@@ -467,14 +467,6 @@ ensure_tuning (GstVaapiFeiEncH264 * feienc)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (feienc);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      feienc->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -1268,6 +1260,11 @@ ensure_profile_and_level (GstVaapiFeiEncH264 * feienc)
     GST_WARNING ("Failed to set some of the tuning option as expected! ");
 
   if (!ensure_profile (feienc) || !ensure_profile_limits (feienc))
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
+  feienc->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (feienc));
+  if (feienc->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
   /* Check HW constraints */

--- a/gst-libs/gst/vaapi/gstvaapiprofile.h
+++ b/gst-libs/gst/vaapi/gstvaapiprofile.h
@@ -188,6 +188,7 @@ typedef enum {
 
 /**
  * GstVaapiEntrypoint:
+ * @GST_VAAPI_ENTRYPOINT_INVALID: Invalid entrypoint
  * @GST_VAAPI_ENTRYPOINT_VLD: Variable Length Decoding
  * @GST_VAAPI_ENTRYPOINT_IDCT: Inverse Decrete Cosine Transform
  * @GST_VAAPI_ENTRYPOINT_MOCO: Motion Compensation
@@ -200,7 +201,8 @@ typedef enum {
  * The set of all entrypoints for #GstVaapiEntrypoint
  */
 typedef enum {
-    GST_VAAPI_ENTRYPOINT_VLD = 1,
+    GST_VAAPI_ENTRYPOINT_INVALID,
+    GST_VAAPI_ENTRYPOINT_VLD,
     GST_VAAPI_ENTRYPOINT_IDCT,
     GST_VAAPI_ENTRYPOINT_MOCO,
     GST_VAAPI_ENTRYPOINT_SLICE_ENCODE,


### PR DESCRIPTION
Some profile such as H265_MAIN_444 may only supported in entrypoint
of ENTRYPOINT_SLICE_ENCODE_LP. This leads two problems,
1. We need to specify the tune mode like
     vaapih265enc tune=low-power
   every time when we need to use this kind of profile. Or we can not
   create the encoder context successfully.
2. More serious, we set the entrypoint to a fixed value in
   init_context_info and so the create_test_context_config can not
   create the test context for these profile and can not get the
   supported video formats, either.

We now change the entrypoint setting based on the tune option of the
encoder. If no tune property provided, we just choose the first
available entrypoint.