### PR TITLE
plugins: base: do not reset can_dmabuf

### DIFF
--- a/gst/vaapi/gstvaapipluginbase.c
+++ b/gst/vaapi/gstvaapipluginbase.c
@@ -68,7 +68,6 @@ gst_vaapi_pad_private_reset (GstVaapiPadPrivate * priv)
   priv->caps_is_raw = FALSE;
 
   g_clear_object (&priv->other_allocator);
-  priv->can_dmabuf = FALSE;
 }
 
 void


### PR DESCRIPTION
Don't reset the can_dmabuf field.  This restores the
close/reset logic that existed prior to commit
ca2942176b5632e07eebac23336954f9aaf1cb26 in regards to
dmabuf support.

Plugins only call gst_vaapi_plugin_base_set_srcpad_can_dmabuf
once during startup, but may need to reset the other private
fields multiple times during negotiation.  Thus, can_dmabuf
should be exempt from the resets.
