### PR TITLE
plugin: encode: set allowed_sinkpad_caps to empty.

### DIFF
--- a/gst/vaapi/gstvaapiencode.c
+++ b/gst/vaapi/gstvaapiencode.c
@@ -451,11 +451,13 @@ bail:
 
 failed_get_formats:
   {
+    gst_caps_replace (&encode->allowed_sinkpad_caps, gst_caps_new_empty ());
     GST_WARNING_OBJECT (encode, "failed to get allowed surface formats");
     goto bail;
   }
 failed_create_raw_caps:
   {
+    gst_caps_replace (&encode->allowed_sinkpad_caps, gst_caps_new_empty ());
     GST_WARNING_OBJECT (encode, "failed to create raw sink caps");
     goto bail;
   }


### PR DESCRIPTION
We now set encode->allowed_sinkpad_caps to NULL if we fail to get
surfaces formats. This causes two problem:
1. gst_video_encoder_proxy_getcaps use NULL as its caps parameter,
which changes its behavior. It will use encode's sinkpad template
rather than empty caps to do the clip job. So even if we fail to set
allowed_sinkpad_caps, gst_video_encoder_proxy_getcaps can still return
valid caps.
2. We should just set the allowed_sinkpad_caps once. The NULL point
make the ensure_allowed_sinkpad_caps function works again and again.