### PR TITLE
libs: encoder: Set entrypoint based on tune automatically.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicontext.c
+++ b/gst-libs/gst/vaapi/gstvaapicontext.c
@@ -409,9 +409,11 @@ gst_vaapi_context_new (GstVaapiDisplay * display,
 {
   GstVaapiContext *context;
 
-  g_return_val_if_fail (cip->profile, NULL);
-  g_return_val_if_fail (cip->entrypoint, NULL);
   g_return_val_if_fail (display, NULL);
+
+  if (cip->profile == GST_VAAPI_PROFILE_UNKNOWN
+      || cip->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return NULL;
 
   context = g_slice_new (GstVaapiContext);
   if (!context)
@@ -469,6 +471,10 @@ gst_vaapi_context_reset (GstVaapiContext * context,
   gboolean reset_surfaces = FALSE, reset_config = FALSE;
   gboolean grow_surfaces = FALSE;
   GstVaapiChromaType chroma_type;
+
+  if (new_cip->profile == GST_VAAPI_PROFILE_UNKNOWN
+      || new_cip->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return FALSE;
 
   chroma_type = new_cip->chroma_type ? new_cip->chroma_type :
       DEFAULT_CHROMA_TYPE;

--- a/gst-libs/gst/vaapi/gstvaapiencoder.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.h
@@ -187,6 +187,10 @@ gst_vaapi_encoder_get_surface_formats (GstVaapiEncoder * encoder,
 GstVaapiProfile
 gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder);
 
+GstVaapiEntrypoint
+gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder,
+    GstVaapiProfile profile);
+
 G_END_DECLS
 
 #endif /* GST_VAAPI_ENCODER_H */

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264_fei.c
@@ -1280,14 +1280,6 @@ ensure_tuning (GstVaapiEncoderH264Fei * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2623,6 +2615,14 @@ ensure_profile_and_level (GstVaapiEncoderH264Fei * encoder)
 
   if (!ensure_tuning (encoder))
     GST_WARNING ("Failed to set some of the tuning option as expected! ");
+
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder),
+      encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
 
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
@@ -1082,10 +1082,6 @@ ensure_tuning (GstVaapiEncoderH265 * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2038,6 +2034,14 @@ ensure_profile_tier_level (GstVaapiEncoderH265 * encoder)
 
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder),
+      encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
 
   /* Check HW constraints */
   if (!ensure_hw_profile_limits (encoder))

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
@@ -427,8 +427,8 @@ update_ref_list (GstVaapiEncoderVP9 * encoder, GstVaapiEncPicture * picture,
       gst_vaapi_surface_proxy_unref (ref);
       break;
     case GST_VAAPI_ENCODER_VP9_REF_PIC_MODE_1:
-      gst_vaapi_surface_proxy_replace (&encoder->ref_list[encoder->
-              ref_list_idx], ref);
+      gst_vaapi_surface_proxy_replace (&encoder->
+          ref_list[encoder->ref_list_idx], ref);
       gst_vaapi_surface_proxy_unref (ref);
       encoder->ref_list_idx = (encoder->ref_list_idx + 1) % GST_VP9_REF_FRAMES;
       break;
@@ -526,8 +526,13 @@ gst_vaapi_encoder_vp9_reconfigure (GstVaapiEncoder * base_encoder)
   if (status != GST_VAAPI_ENCODER_STATUS_SUCCESS)
     return status;
 
-  if (GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER)
-    encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (base_encoder, encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
+
   ensure_control_rate_params (encoder);
   return set_context_info (base_encoder);
 }

--- a/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapifeienc_h264.c
@@ -467,14 +467,6 @@ ensure_tuning (GstVaapiFeiEncH264 * feienc)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (feienc);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      feienc->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -1269,6 +1261,14 @@ ensure_profile_and_level (GstVaapiFeiEncH264 * feienc)
 
   if (!ensure_profile (feienc) || !ensure_profile_limits (feienc))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+
+  feienc->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (feienc),
+      feienc->profile);
+  if (feienc->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
 
   /* Check HW constraints */
   if (!ensure_hw_profile_limits (feienc))

--- a/gst-libs/gst/vaapi/gstvaapiprofile.h
+++ b/gst-libs/gst/vaapi/gstvaapiprofile.h
@@ -188,6 +188,7 @@ typedef enum {
 
 /**
  * GstVaapiEntrypoint:
+ * @GST_VAAPI_ENTRYPOINT_INVALID: Invalid entrypoint
  * @GST_VAAPI_ENTRYPOINT_VLD: Variable Length Decoding
  * @GST_VAAPI_ENTRYPOINT_IDCT: Inverse Decrete Cosine Transform
  * @GST_VAAPI_ENTRYPOINT_MOCO: Motion Compensation
@@ -200,7 +201,8 @@ typedef enum {
  * The set of all entrypoints for #GstVaapiEntrypoint
  */
 typedef enum {
-    GST_VAAPI_ENTRYPOINT_VLD = 1,
+    GST_VAAPI_ENTRYPOINT_INVALID,
+    GST_VAAPI_ENTRYPOINT_VLD,
     GST_VAAPI_ENTRYPOINT_IDCT,
     GST_VAAPI_ENTRYPOINT_MOCO,
     GST_VAAPI_ENTRYPOINT_SLICE_ENCODE,


### PR DESCRIPTION
Some profile such as H265_MAIN_444 may only supported in entrypoint
of ENTRYPOINT_SLICE_ENCODE_LP. This leads two problems,
1. We need to specify the tune mode like
     vaapih265enc tune=low-power
   every time when we need to use this kind of profile. Or we can not
   create the encoder context successfully.
2. More serious, we set the entrypoint to a fixed value in
   init_context_info and so the create_test_context_config can not
   create the test context for these profile and can not get the
   supported video formats, either.

We now change the entrypoint setting based on the tune option of the
encoder. If no tune property provided, we just choose the first
available entrypoint.