### PR TITLE
libs: encoder: Set entrypoint based on tune automatically.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapicontext.c
+++ b/gst-libs/gst/vaapi/gstvaapicontext.c
@@ -409,9 +409,11 @@ gst_vaapi_context_new (GstVaapiDisplay * display,
 {
   GstVaapiContext *context;
 
-  g_return_val_if_fail (cip->profile, NULL);
-  g_return_val_if_fail (cip->entrypoint, NULL);
   g_return_val_if_fail (display, NULL);
+
+  if (cip->profile == GST_VAAPI_PROFILE_UNKNOWN
+      || cip->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return NULL;
 
   context = g_slice_new (GstVaapiContext);
   if (!context)
@@ -469,6 +471,10 @@ gst_vaapi_context_reset (GstVaapiContext * context,
   gboolean reset_surfaces = FALSE, reset_config = FALSE;
   gboolean grow_surfaces = FALSE;
   GstVaapiChromaType chroma_type;
+
+  if (new_cip->profile == GST_VAAPI_PROFILE_UNKNOWN
+      || new_cip->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID)
+    return FALSE;
 
   chroma_type = new_cip->chroma_type ? new_cip->chroma_type :
       DEFAULT_CHROMA_TYPE;

--- a/gst-libs/gst/vaapi/gstvaapiencoder.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.c
@@ -713,21 +713,9 @@ get_default_chroma_type (GstVaapiEncoder * encoder,
 }
 
 static void
-init_context_info (GstVaapiEncoder * encoder, GstVaapiContextInfo * cip,
-    GstVaapiProfile profile)
+init_context_info (GstVaapiEncoder * encoder, GstVaapiContextInfo * cip)
 {
-  const GstVaapiEncoderClassData *const cdata =
-      GST_VAAPI_ENCODER_GET_CLASS (encoder)->class_data;
-
   cip->usage = GST_VAAPI_CONTEXT_USAGE_ENCODE;
-  cip->profile = profile;
-  if (cdata->codec == GST_VAAPI_CODEC_JPEG) {
-    cip->entrypoint = GST_VAAPI_ENTRYPOINT_PICTURE_ENCODE;
-  } else {
-    if (cip->entrypoint != GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP &&
-        cip->entrypoint != GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_FEI)
-      cip->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
-  }
   cip->chroma_type = get_default_chroma_type (encoder, cip);
   cip->width = 0;
   cip->height = 0;
@@ -744,8 +732,10 @@ set_context_info (GstVaapiEncoder * encoder)
       GST_VIDEO_INFO_FORMAT (GST_VAAPI_ENCODER_VIDEO_INFO (encoder));
   guint fei_function = config->fei_function;
 
-  init_context_info (encoder, cip, get_profile (encoder));
+  g_assert (cip->profile != GST_VAAPI_PROFILE_UNKNOWN);
+  g_assert (cip->entrypoint != GST_VAAPI_ENTRYPOINT_INVALID);
 
+  init_context_info (encoder, cip);
   cip->chroma_type = gst_vaapi_video_format_get_chroma_type (format);
   cip->width = GST_VAAPI_ENCODER_WIDTH (encoder);
   cip->height = GST_VAAPI_ENCODER_HEIGHT (encoder);
@@ -1493,7 +1483,18 @@ create_test_context_config (GstVaapiEncoder * encoder, GstVaapiProfile profile)
   if (profile == GST_VAAPI_PROFILE_UNKNOWN)
     profile = get_profile (encoder);
 
-  init_context_info (encoder, &cip, profile);
+  cip.profile = profile;
+  cip.entrypoint = gst_vaapi_encoder_get_entrypoint (encoder, profile);
+  if (cip.entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_INFO ("can not find %s entrypoint for profile %s to create"
+        " text context. Ignore this profile",
+        GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER ?
+        "the low-power" : "an available",
+        gst_vaapi_profile_get_va_name (profile));
+    return NULL;
+  }
+
+  init_context_info (encoder, &cip);
   ctxt = gst_vaapi_context_new (encoder->display, &cip);
   return ctxt;
 }
@@ -1507,6 +1508,7 @@ get_profile_surface_formats (GstVaapiEncoder * encoder, GstVaapiProfile profile)
   ctxt = create_test_context_config (encoder, profile);
   if (!ctxt)
     return NULL;
+
   formats = gst_vaapi_context_get_surface_formats (ctxt);
   gst_vaapi_context_unref (ctxt);
   return formats;
@@ -1683,6 +1685,50 @@ gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder)
   g_return_val_if_fail (encoder, GST_VAAPI_PROFILE_UNKNOWN);
 
   return encoder->profile;
+}
+
+/* Get the entrypoint based on the tune option. */
+/**
+ * gst_vaapi_encoder_get_entrypoint:
+ * @encoder: a #GstVaapiEncoder
+ * @profile: a #GstVaapiProfile
+ *
+ * This function will return the valid entrypoint of the @encoder for
+ * @profile. If the low-power mode(tune option) is set, only LP
+ * entrypoints will be considered. If not, the first available entry
+ * point will be return.
+ *
+ * Returns: The #GstVaapiEntrypoint.
+ **/
+GstVaapiEntrypoint
+gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder,
+    GstVaapiProfile profile)
+{
+  /* XXX: The profile may not be the same with encoder->profile */
+
+  g_return_val_if_fail (encoder, GST_VAAPI_ENTRYPOINT_INVALID);
+  g_return_val_if_fail (profile != GST_VAAPI_PROFILE_UNKNOWN,
+      GST_VAAPI_ENTRYPOINT_INVALID);
+
+  if (profile == GST_VAAPI_PROFILE_JPEG_BASELINE)
+    return GST_VAAPI_ENTRYPOINT_PICTURE_ENCODE;
+
+  if (GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER) {
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  } else {
+    /* If not set, choose the available one */
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
+
+    if (gst_vaapi_display_has_encoder (GST_VAAPI_ENCODER_DISPLAY (encoder),
+            profile, GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP))
+      return GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  }
+
+  return GST_VAAPI_ENTRYPOINT_INVALID;
 }
 
 /** Returns a GType for the #GstVaapiEncoderTune set */

--- a/gst-libs/gst/vaapi/gstvaapiencoder.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.h
@@ -187,6 +187,10 @@ gst_vaapi_encoder_get_surface_formats (GstVaapiEncoder * encoder,
 GstVaapiProfile
 gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder);
 
+GstVaapiEntrypoint
+gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder,
+    GstVaapiProfile profile);
+
 G_END_DECLS
 
 #endif /* GST_VAAPI_ENCODER_H */

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h264.c
@@ -1301,14 +1301,6 @@ ensure_tuning (GstVaapiEncoderH264 * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      /* Set low-power encode entry point. If hardware doesn't have
-       * support, it will fail in ensure_hw_profile() in later stage.
-       * So not duplicating the profile/entrypont query mechanism
-       * here as a part of optimization */
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2738,6 +2730,16 @@ ensure_profile_and_level (GstVaapiEncoderH264 * encoder)
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
+  /* If set low-power encode entry point and hardware doesn't have
+   * support, it will fail in ensure_hw_profile() in later stage. */
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder),
+      encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
+
   /* Check HW constraints */
   if (!ensure_hw_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
@@ -3346,7 +3348,7 @@ set_context_info (GstVaapiEncoder * base_encoder)
       GST_VAAPI_ENCODER_H264_COMPLIANCE_MODE_RESTRICT_CODED_BUFFER_ALLOC)
     base_encoder->codedbuf_size /= encoder->min_cr;
 
-
+  base_encoder->context_info.profile = base_encoder->profile;
   base_encoder->context_info.entrypoint = encoder->entrypoint;
 
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;

--- a/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_h265.c
@@ -1082,10 +1082,6 @@ ensure_tuning (GstVaapiEncoderH265 * encoder)
     case GST_VAAPI_ENCODER_TUNE_HIGH_COMPRESSION:
       success = ensure_tuning_high_compression (encoder);
       break;
-    case GST_VAAPI_ENCODER_TUNE_LOW_POWER:
-      encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
-      success = TRUE;
-      break;
     default:
       success = TRUE;
       break;
@@ -2039,6 +2035,14 @@ ensure_profile_tier_level (GstVaapiEncoderH265 * encoder)
   if (!ensure_profile (encoder) || !ensure_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
 
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (GST_VAAPI_ENCODER_CAST (encoder),
+      encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
+
   /* Check HW constraints */
   if (!ensure_hw_profile_limits (encoder))
     return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
@@ -2540,6 +2544,7 @@ set_context_info (GstVaapiEncoder * base_encoder)
   base_encoder->codedbuf_size += GST_ROUND_UP_16 (vip->width) *
       GST_ROUND_UP_16 (vip->height) * 3 / 2;
 
+  base_encoder->context_info.profile = base_encoder->profile;
   base_encoder->context_info.entrypoint = encoder->entrypoint;
 
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;

--- a/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
@@ -197,6 +197,9 @@ set_context_info (GstVaapiEncoder * base_encoder)
   base_encoder->codedbuf_size += MAX_APP_HDR_SIZE + MAX_FRAME_HDR_SIZE +
       MAX_QUANT_TABLE_SIZE + MAX_HUFFMAN_TABLE_SIZE + MAX_SCAN_HDR_SIZE;
 
+  base_encoder->context_info.profile = base_encoder->profile;
+  base_encoder->context_info.entrypoint = GST_VAAPI_ENTRYPOINT_PICTURE_ENCODE;
+
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;
 }
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_mpeg2.c
@@ -689,6 +689,9 @@ set_context_info (GstVaapiEncoder * base_encoder)
   base_encoder->codedbuf_size += (GST_ROUND_UP_16 (vip->height) / 16) *
       MAX_SLICE_HDR_SIZE;
 
+  base_encoder->context_info.profile = base_encoder->profile;
+  base_encoder->context_info.entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
+
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;
 }
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp8.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp8.c
@@ -173,6 +173,9 @@ set_context_info (GstVaapiEncoder * base_encoder)
       MAX_TOKEN_PROB_UPDATE_SIZE + MAX_MV_PROBE_UPDATE_SIZE +
       MAX_REST_OF_FRAME_HDR_SIZE;
 
+  base_encoder->context_info.profile = base_encoder->profile;
+  base_encoder->context_info.entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE;
+
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;
 }
 

--- a/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
+++ b/gst-libs/gst/vaapi/gstvaapiencoder_vp9.c
@@ -219,6 +219,7 @@ set_context_info (GstVaapiEncoder * base_encoder)
   base_encoder->codedbuf_size = GST_ROUND_UP_16 (vip->width) *
       GST_ROUND_UP_16 (vip->height) * 3 / 2;
 
+  base_encoder->context_info.profile = base_encoder->profile;
   base_encoder->context_info.entrypoint = encoder->entrypoint;
 
   return GST_VAAPI_ENCODER_STATUS_SUCCESS;
@@ -427,8 +428,8 @@ update_ref_list (GstVaapiEncoderVP9 * encoder, GstVaapiEncPicture * picture,
       gst_vaapi_surface_proxy_unref (ref);
       break;
     case GST_VAAPI_ENCODER_VP9_REF_PIC_MODE_1:
-      gst_vaapi_surface_proxy_replace (&encoder->ref_list[encoder->
-              ref_list_idx], ref);
+      gst_vaapi_surface_proxy_replace (&encoder->
+          ref_list[encoder->ref_list_idx], ref);
       gst_vaapi_surface_proxy_unref (ref);
       encoder->ref_list_idx = (encoder->ref_list_idx + 1) % GST_VP9_REF_FRAMES;
       break;
@@ -526,8 +527,13 @@ gst_vaapi_encoder_vp9_reconfigure (GstVaapiEncoder * base_encoder)
   if (status != GST_VAAPI_ENCODER_STATUS_SUCCESS)
     return status;
 
-  if (GST_VAAPI_ENCODER_TUNE (encoder) == GST_VAAPI_ENCODER_TUNE_LOW_POWER)
-    encoder->entrypoint = GST_VAAPI_ENTRYPOINT_SLICE_ENCODE_LP;
+  encoder->entrypoint =
+      gst_vaapi_encoder_get_entrypoint (base_encoder, encoder->profile);
+  if (encoder->entrypoint == GST_VAAPI_ENTRYPOINT_INVALID) {
+    GST_WARNING ("Cannot find valid entrypoint");
+    return GST_VAAPI_ENCODER_STATUS_ERROR_UNSUPPORTED_PROFILE;
+  }
+
   ensure_control_rate_params (encoder);
   return set_context_info (base_encoder);
 }

--- a/gst-libs/gst/vaapi/gstvaapiprofile.h
+++ b/gst-libs/gst/vaapi/gstvaapiprofile.h
@@ -188,6 +188,7 @@ typedef enum {
 
 /**
  * GstVaapiEntrypoint:
+ * @GST_VAAPI_ENTRYPOINT_INVALID: Invalid entrypoint
  * @GST_VAAPI_ENTRYPOINT_VLD: Variable Length Decoding
  * @GST_VAAPI_ENTRYPOINT_IDCT: Inverse Decrete Cosine Transform
  * @GST_VAAPI_ENTRYPOINT_MOCO: Motion Compensation
@@ -200,7 +201,8 @@ typedef enum {
  * The set of all entrypoints for #GstVaapiEntrypoint
  */
 typedef enum {
-    GST_VAAPI_ENTRYPOINT_VLD = 1,
+    GST_VAAPI_ENTRYPOINT_INVALID,
+    GST_VAAPI_ENTRYPOINT_VLD,
     GST_VAAPI_ENTRYPOINT_IDCT,
     GST_VAAPI_ENTRYPOINT_MOCO,
     GST_VAAPI_ENTRYPOINT_SLICE_ENCODE,


### PR DESCRIPTION
Some profile such as H265_MAIN_444 may only supported in entrypoint
of ENTRYPOINT_SLICE_ENCODE_LP. This leads two problems,
1. We need to specify the tune mode like
     vaapih265enc tune=low-power
   every time when we need to use this kind of profile. Or we can not
   create the encoder context successfully.
2. More serious, we set the entrypoint to a fixed value in
   init_context_info and so the create_test_context_config can not
   create the test context for these profile and can not get the
   supported video formats, either.

We now change the entrypoint setting based on the tune option of the
encoder. If no tune property provided, we just choose the first
available entrypoint.