### PR TITLE
plugin: encode: List all possible profiles to detect input formats.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapiencoder.h
+++ b/gst-libs/gst/vaapi/gstvaapiencoder.h
@@ -182,7 +182,7 @@ gst_vaapi_encoder_flush (GstVaapiEncoder * encoder);
 
 GArray *
 gst_vaapi_encoder_get_surface_attributes (GstVaapiEncoder * encoder,
-    GstVaapiProfile profile, gint * min_width, gint * min_height,
+    GArray * profiles, gint * min_width, gint * min_height,
     gint * max_width, gint * max_height);
 
 GstVaapiProfile
@@ -191,6 +191,9 @@ gst_vaapi_encoder_get_profile (GstVaapiEncoder * encoder);
 GstVaapiEntrypoint
 gst_vaapi_encoder_get_entrypoint (GstVaapiEncoder * encoder,
     GstVaapiProfile profile);
+
+GstVaapiCodec
+gst_vaapi_encoder_get_codec (GstVaapiEncoder * encoder);
 
 G_END_DECLS
 

--- a/gst/vaapi/gstvaapiencode.c
+++ b/gst/vaapi/gstvaapiencode.c
@@ -340,30 +340,59 @@ gst_vaapiencode_buffer_loop (GstVaapiEncode * encode)
   gst_pad_pause_task (GST_VAAPI_PLUGIN_BASE_SRC_PAD (encode));
 }
 
-static GstVaapiProfile
-get_profile (GstVaapiEncode * encode)
+static GArray *
+get_profiles (GstVaapiEncode * encode)
 {
   GstVaapiEncodeClass *klass = GST_VAAPIENCODE_GET_CLASS (encode);
+  GArray *profiles = NULL;
+  GArray *all_profiles = NULL;
+  GstVaapiProfile profile;
+  guint i;
+  GstVaapiCodec codec;
 
-  if (klass->get_profile) {
-    GstVaapiProfile profile = GST_VAAPI_PROFILE_UNKNOWN;
+  if (klass->get_allowed_profiles) {
     GstCaps *allowed =
         gst_pad_get_allowed_caps (GST_VAAPI_PLUGIN_BASE_SRC_PAD (encode));
+    GST_LOG_OBJECT (encode,
+        "Get allowed sink caps from downstream %" GST_PTR_FORMAT, allowed);
+    if (allowed && !gst_caps_is_empty (allowed) && !gst_caps_is_any (allowed))
+      profiles = klass->get_allowed_profiles (encode, allowed);
 
-    if (allowed) {
-      if (!gst_caps_is_empty (allowed) && !gst_caps_is_any (allowed))
-        profile = klass->get_profile (allowed);
+    if (allowed)
       gst_caps_unref (allowed);
-    }
 
-    if (profile != GST_VAAPI_PROFILE_UNKNOWN)
-      return profile;
+    if (profiles)
+      goto out;
   }
 
-  if (encode->encoder)
-    return gst_vaapi_encoder_get_profile (encode->encoder);
+  all_profiles = gst_vaapi_display_get_encode_profiles
+      (GST_VAAPI_PLUGIN_BASE_DISPLAY (encode));
+  if (!all_profiles)
+    goto out;
 
-  return GST_VAAPI_PROFILE_UNKNOWN;
+  /* Add all supported profiles belong to current codec */
+  profiles = g_array_new (FALSE, FALSE, sizeof (GstVaapiProfile));
+  if (!profiles)
+    goto out;
+
+  codec = gst_vaapi_encoder_get_codec (encode->encoder);
+  g_assert (codec);
+
+  for (i = 0; i < all_profiles->len; i++) {
+    profile = g_array_index (all_profiles, GstVaapiProfile, i);
+    if (gst_vaapi_profile_get_codec (profile) == codec)
+      g_array_append_val (profiles, profile);
+  }
+
+out:
+  if (all_profiles)
+    g_array_unref (all_profiles);
+  if (profiles && profiles->len == 0) {
+    g_array_unref (profiles);
+    profiles = NULL;
+  }
+
+  return profiles;
 }
 
 static gboolean
@@ -374,7 +403,7 @@ ensure_allowed_sinkpad_caps (GstVaapiEncode * encode)
   GstCaps *va_caps, *dma_caps;
   GArray *formats = NULL;
   gboolean ret = FALSE;
-  GstVaapiProfile profile;
+  GArray *profiles = NULL;
   guint i, size;
   GstStructure *structure;
   gint min_width, min_height, max_width, max_height;
@@ -384,11 +413,14 @@ ensure_allowed_sinkpad_caps (GstVaapiEncode * encode)
   if (!encode->encoder)
     return TRUE;
 
-  profile = get_profile (encode);
+  /* First, get all possible profiles. */
+  profiles = get_profiles (encode);
+  if (profiles == NULL)
+    goto failed_get_profiles;
 
-  /* First get all supported formats, all these formats should be recognized
+  /* Then get all supported formats, all these formats should be recognized
      in video-format map. */
-  formats = gst_vaapi_encoder_get_surface_attributes (encode->encoder, profile,
+  formats = gst_vaapi_encoder_get_surface_attributes (encode->encoder, profiles,
       &min_width, &min_height, &max_width, &max_height);
   if (!formats)
     goto failed_get_attributes;
@@ -431,6 +463,8 @@ bail:
   if (!encode->allowed_sinkpad_caps)
     encode->allowed_sinkpad_caps = gst_caps_new_empty ();
 
+  if (profiles)
+    g_array_unref (profiles);
   if (out_caps)
     gst_caps_unref (out_caps);
   if (raw_caps)
@@ -447,6 +481,11 @@ failed_get_attributes:
 failed_create_raw_caps:
   {
     GST_WARNING_OBJECT (encode, "failed to create raw sink caps");
+    goto bail;
+  }
+failed_get_profiles:
+  {
+    GST_WARNING_OBJECT (encode, "failed to get supported profiles");
     goto bail;
   }
 }

--- a/gst/vaapi/gstvaapiencode.h
+++ b/gst/vaapi/gstvaapiencode.h
@@ -81,7 +81,9 @@ struct _GstVaapiEncodeClass
   GstFlowReturn       (*alloc_buffer)   (GstVaapiEncode * encode,
                                          GstVaapiCodedBuffer * coded_buf,
                                          GstBuffer ** outbuf_ptr);
-  GstVaapiProfile     (*get_profile)    (GstCaps * caps);
+  /* Get all possible profiles based on allowed caps */
+  GArray *            (*get_allowed_profiles)  (GstVaapiEncode * encode,
+                                                GstCaps * allowed);
 
 #if USE_H264_FEI_ENCODER
 

--- a/gst/vaapi/gstvaapiencode_h264.c
+++ b/gst/vaapi/gstvaapiencode_h264.c
@@ -128,23 +128,12 @@ gst_vaapiencode_h264_finalize (GObject * object)
   G_OBJECT_CLASS (gst_vaapiencode_h264_parent_class)->finalize (object);
 }
 
-static GstVaapiProfile
-gst_vaapiencode_h264_get_profile (GstCaps * caps)
+static GArray *
+gst_vaapiencode_h264_get_allowed_profiles (GstVaapiEncode * encode,
+    GstCaps * allowed)
 {
-  guint i;
-
-  for (i = 0; i < gst_caps_get_size (caps); i++) {
-    GstStructure *const structure = gst_caps_get_structure (caps, i);
-    const GValue *const value = gst_structure_get_value (structure, "profile");
-
-    if (value && G_VALUE_HOLDS_STRING (value)) {
-      const gchar *str = g_value_get_string (value);
-      if (str)
-        return gst_vaapi_utils_h264_get_profile_from_string (str);
-    }
-  }
-
-  return GST_VAAPI_PROFILE_UNKNOWN;
+  return gst_vaapi_caps_get_profiles (allowed,
+      gst_vaapi_utils_h264_get_profile_from_string);
 }
 
 typedef struct
@@ -556,7 +545,8 @@ gst_vaapiencode_h264_class_init (GstVaapiEncodeH264Class * klass)
   object_class->set_property = gst_vaapiencode_set_property_subclass;
   object_class->get_property = gst_vaapiencode_get_property_subclass;
 
-  encode_class->get_profile = gst_vaapiencode_h264_get_profile;
+  encode_class->get_allowed_profiles =
+      gst_vaapiencode_h264_get_allowed_profiles;
   encode_class->set_config = gst_vaapiencode_h264_set_config;
   encode_class->get_caps = gst_vaapiencode_h264_get_caps;
   encode_class->alloc_encoder = gst_vaapiencode_h264_alloc_encoder;

--- a/gst/vaapi/gstvaapiencode_h265.c
+++ b/gst/vaapi/gstvaapiencode_h265.c
@@ -99,23 +99,12 @@ gst_vaapiencode_h265_finalize (GObject * object)
   G_OBJECT_CLASS (gst_vaapiencode_h265_parent_class)->finalize (object);
 }
 
-static GstVaapiProfile
-gst_vaapiencode_h265_get_profile (GstCaps * caps)
+static GArray *
+gst_vaapiencode_h265_get_allowed_profiles (GstVaapiEncode * encode,
+    GstCaps * allowed)
 {
-  guint i;
-
-  for (i = 0; i < gst_caps_get_size (caps); i++) {
-    GstStructure *const structure = gst_caps_get_structure (caps, i);
-    const GValue *const value = gst_structure_get_value (structure, "profile");
-
-    if (value && G_VALUE_HOLDS_STRING (value)) {
-      const gchar *str = g_value_get_string (value);
-      if (str)
-        return gst_vaapi_utils_h265_get_profile_from_string (str);
-    }
-  }
-
-  return GST_VAAPI_PROFILE_UNKNOWN;
+  return gst_vaapi_caps_get_profiles (allowed,
+      gst_vaapi_utils_h265_get_profile_from_string);
 }
 
 typedef struct
@@ -386,7 +375,8 @@ gst_vaapiencode_h265_class_init (GstVaapiEncodeH265Class * klass)
   object_class->set_property = gst_vaapiencode_set_property_subclass;
   object_class->get_property = gst_vaapiencode_get_property_subclass;
 
-  encode_class->get_profile = gst_vaapiencode_h265_get_profile;
+  encode_class->get_allowed_profiles =
+      gst_vaapiencode_h265_get_allowed_profiles;
   encode_class->set_config = gst_vaapiencode_h265_set_config;
   encode_class->get_caps = gst_vaapiencode_h265_get_caps;
   encode_class->alloc_encoder = gst_vaapiencode_h265_alloc_encoder;

--- a/gst/vaapi/gstvaapipluginutil.c
+++ b/gst/vaapi/gstvaapipluginutil.c
@@ -1007,3 +1007,64 @@ gst_vaapi_codecs_has_codec (GArray * codecs, GstVaapiCodec codec)
   }
   return FALSE;
 }
+
+/**
+ * gst_vaapi_caps_get_profiles:
+ * @caps: a #GstCaps to detect
+ * @func: a #GstVaapiStrToProfileFunc
+ *
+ * This function will detect all profile strings and return
+ * the according GstVaapiProfile array.
+ *
+ * Return: A #GArray of @GstVaapiProfile if succeed, %NULL if fail.
+ **/
+GArray *
+gst_vaapi_caps_get_profiles (GstCaps * caps, GstVaapiStrToProfileFunc func)
+{
+  guint i, j;
+  GstVaapiProfile profile;
+  GArray *profiles = NULL;
+
+  if (!caps)
+    return NULL;
+
+  profiles = g_array_new (FALSE, FALSE, sizeof (GstVaapiProfile));
+  if (!profiles)
+    return NULL;
+
+  for (i = 0; i < gst_caps_get_size (caps); i++) {
+    GstStructure *const structure = gst_caps_get_structure (caps, i);
+    const GValue *const value = gst_structure_get_value (structure, "profile");
+
+    if (value && G_VALUE_HOLDS_STRING (value)) {
+      const gchar *str = g_value_get_string (value);
+      if (str) {
+        profile = func (str);
+        if (profile != GST_VAAPI_PROFILE_UNKNOWN)
+          g_array_append_val (profiles, profile);
+      }
+    } else if (value && GST_VALUE_HOLDS_LIST (value)) {
+      const GValue *v;
+      const gchar *str;
+      for (j = 0; j < gst_value_list_get_size (value); j++) {
+        v = gst_value_list_get_value (value, j);
+        if (!v || !G_VALUE_HOLDS_STRING (v))
+          continue;
+
+        str = g_value_get_string (v);
+        if (str) {
+          profile = func (str);
+          if (profile != GST_VAAPI_PROFILE_UNKNOWN)
+            g_array_append_val (profiles, profile);
+        }
+      }
+    }
+  }
+
+  if (profiles->len == 0) {
+    g_array_unref (profiles);
+    profiles = NULL;
+  }
+
+  return profiles;
+}

--- a/gst/vaapi/gstvaapipluginutil.h
+++ b/gst/vaapi/gstvaapipluginutil.h
@@ -29,6 +29,9 @@
 #include <gst/vaapi/gstvaapisurface.h>
 #include "gstvaapivideomemory.h"
 
+typedef GstVaapiProfile (*GstVaapiStrToProfileFunc) (const gchar * str);
+
+
 G_GNUC_INTERNAL
 gboolean
 gst_vaapi_ensure_display (GstElement * element, GstVaapiDisplayType type);
@@ -151,5 +154,9 @@ gst_vaapi_driver_is_whitelisted (GstVaapiDisplay * display);
 G_GNUC_INTERNAL
 gboolean
 gst_vaapi_codecs_has_codec (GArray * codecs, GstVaapiCodec codec);
+
+G_GNUC_INTERNAL
+GArray *
+gst_vaapi_caps_get_profiles (GstCaps * caps, GstVaapiStrToProfileFunc func);
 
 #endif /* GST_VAAPI_PLUGIN_UTIL_H */


### PR DESCRIPTION
The current get_profile just return one possible profile for the encode,
which is not enough.  For example, if we want to support HEVC 4:4:4
profile, the input of encode should be VYUA rather than NV12 in HEVC
main profile. So the command line:

gst-launch-1.0 videotestsrc num-buffers=200 ! capsfilter \
caps=video/x-raw,format=VUYA,width=800,height=600 ! vaapih265enc \
tune=low-power init-qp=30 ! fakesink

can not work because vaapih265enc just report NV12 in sink caps, we need
to specify the profile obviously like:

gst-launch-1.0 videotestsrc num-buffers=200 ! capsfilter \
caps=video/x-raw,format=VUYA,width=800,height=600 ! vaapih265enc \
tune=low-power init-qp=30 ! capsfilter caps=video/x-h265, \
profile=main-444 ! fakesink

The encode should have the ability to choose the profile based on input
format automatically. If the input video format is VUYA, the main-444
profile should be auto choosed.

We modify to let get_allowed_profiles return an array of all supported
profiles based on downstream's allowed caps, or return NULL if no profile
specified downstream or the encode do not provide get_profile() function.
The function gst_vaapi_encoder_get_surface_attributes collects the surface's
attributes for profiles allowed, or for all profiles which belong to the
current encoder's codec.

So for this case, both NV12 and VUYA should be returned.

TODO: some codec like VP9, need to implement the get_profile() function.