### PR TITLE
vaapivideobufferpool: Reuse internal allocator is possible.

### DIFF
--- a/gst/vaapi/gstvaapivideobufferpool.c
+++ b/gst/vaapi/gstvaapivideobufferpool.c
@@ -162,8 +162,14 @@ gst_vaapi_video_buffer_pool_set_config (GstBufferPool * pool,
   if (allocator
       && (g_strcmp0 (allocator->mem_type, GST_VAAPI_VIDEO_MEMORY_NAME) != 0
           && g_strcmp0 (allocator->mem_type,
-              GST_VAAPI_DMABUF_ALLOCATOR_NAME) != 0))
-    allocator = NULL;
+              GST_VAAPI_DMABUF_ALLOCATOR_NAME) != 0)) {
+    /* if pool has already an allocator, try it and ignore the one in
+     * configuration */
+    if (priv->allocator)
+      allocator = priv->allocator;
+    else
+      allocator = NULL;
+  }
 
   /* get the allocator properties */
   if (allocator) {


### PR DESCRIPTION
Instead of creating a new allocator when upstream requests a different
allocator, this patch tries to reuse the internal allocator if it was
already initializated.

If the stream changes, then either one will be unref and a new
allocator is created.