### PR TITLE
vaapivideobufferpool: force video meta if sizes are different

### DIFF
--- a/gst/vaapi/gstvaapivideobufferpool.c
+++ b/gst/vaapi/gstvaapivideobufferpool.c
@@ -250,7 +250,9 @@ gst_vaapi_video_buffer_pool_set_config (GstBufferPool * pool,
       if (GST_VIDEO_INFO_PLANE_OFFSET (&new_allocation_vinfo, i) !=
           GST_VIDEO_INFO_PLANE_OFFSET (&priv->vmeta_vinfo, i) ||
           GST_VIDEO_INFO_PLANE_STRIDE (&new_allocation_vinfo, i) !=
-          GST_VIDEO_INFO_PLANE_STRIDE (&priv->vmeta_vinfo, i)) {
+          GST_VIDEO_INFO_PLANE_STRIDE (&priv->vmeta_vinfo, i) ||
+          GST_VIDEO_INFO_SIZE (&new_allocation_vinfo) !=
+          GST_VIDEO_INFO_SIZE (&priv->vmeta_vinfo)) {
         priv->options |= GST_VAAPI_VIDEO_BUFFER_POOL_OPTION_VIDEO_META;
         priv->forced_video_meta = TRUE;
         GST_INFO_OBJECT (base_pool, "adding unrequested video meta");


### PR DESCRIPTION
The strides and offsets could be the same, but the allocation
size might be different (e.g. alignment).  Thus, ensure we also
set the flag to copy from VA memory to system memory when alloc
size differs.
