### PR TITLE
libs plugins: decoder: Add -intra profile support for hevc.

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapiprofile.c
+++ b/gst-libs/gst/vaapi/gstvaapiprofile.c
@@ -426,6 +426,16 @@ gst_vaapi_profile_from_caps (const GstCaps * caps)
         /* HACK: qtdemux does not report profiles for h263 */
         profile = m->profile;
       }
+      if (!profile && profile_str
+          && strncmp (name, "video/x-h265", namelen) == 0
+          && strncmp (profile_str, m->profile_str,
+              strlen (m->profile_str)) == 0
+          && strncmp (profile_str + strlen (m->profile_str),
+              "-intra", 6) == 0) {
+        /* Consider hevc -intra profiles. Just map them to the
+           according non -intra profile */
+        profile = m->profile;
+      }
     }
     gst_caps_unref (caps_test);
   }

--- a/gst-libs/gst/vaapi/gstvaapiutils_h265.c
+++ b/gst-libs/gst/vaapi/gstvaapiutils_h265.c
@@ -184,6 +184,61 @@ gst_vaapi_utils_h265_get_profile (GstH265SPS * sps)
           && sps->profile_tier_level.lower_bit_rate_constraint_flag == 1) {
         profile = GST_VAAPI_PROFILE_H265_MAIN_444_10;
         break;
+      } else if (sps->profile_tier_level.max_12bit_constraint_flag == 1
+          && sps->profile_tier_level.max_10bit_constraint_flag == 1
+          && sps->profile_tier_level.max_8bit_constraint_flag == 1
+          && sps->profile_tier_level.max_422chroma_constraint_flag == 1
+          && sps->profile_tier_level.max_420chroma_constraint_flag == 1
+          && sps->profile_tier_level.max_monochrome_constraint_flag == 0
+          && sps->profile_tier_level.intra_constraint_flag == 1
+          && sps->profile_tier_level.one_picture_only_constraint_flag == 0) {
+        /* Main Intra, recognize it as MAIN */
+        profile = GST_VAAPI_PROFILE_H265_MAIN;
+        break;
+      } else if (sps->profile_tier_level.max_12bit_constraint_flag == 1
+          && sps->profile_tier_level.max_10bit_constraint_flag == 1
+          && sps->profile_tier_level.max_8bit_constraint_flag == 0
+          && sps->profile_tier_level.max_422chroma_constraint_flag == 1
+          && sps->profile_tier_level.max_420chroma_constraint_flag == 1
+          && sps->profile_tier_level.max_monochrome_constraint_flag == 0
+          && sps->profile_tier_level.intra_constraint_flag == 1
+          && sps->profile_tier_level.one_picture_only_constraint_flag == 0) {
+        /* Main 10 Intra, recognize it as MAIN10 */
+        profile = GST_VAAPI_PROFILE_H265_MAIN10;
+        break;
+      } else if (sps->profile_tier_level.max_12bit_constraint_flag == 1
+          && sps->profile_tier_level.max_10bit_constraint_flag == 1
+          && sps->profile_tier_level.max_8bit_constraint_flag == 1
+          && sps->profile_tier_level.max_422chroma_constraint_flag == 0
+          && sps->profile_tier_level.max_420chroma_constraint_flag == 0
+          && sps->profile_tier_level.max_monochrome_constraint_flag == 0
+          && sps->profile_tier_level.intra_constraint_flag == 1
+          && sps->profile_tier_level.one_picture_only_constraint_flag == 0) {
+        /* Main 444 Intra, recognize it as MAIN_444 */
+        profile = GST_VAAPI_PROFILE_H265_MAIN_444;
+        break;
+      } else if (sps->profile_tier_level.max_12bit_constraint_flag == 1
+          && sps->profile_tier_level.max_10bit_constraint_flag == 1
+          && sps->profile_tier_level.max_8bit_constraint_flag == 0
+          && sps->profile_tier_level.max_422chroma_constraint_flag == 0
+          && sps->profile_tier_level.max_420chroma_constraint_flag == 0
+          && sps->profile_tier_level.max_monochrome_constraint_flag == 0
+          && sps->profile_tier_level.intra_constraint_flag == 1
+          && sps->profile_tier_level.one_picture_only_constraint_flag == 0) {
+        /* Main 444_10 Intra, recognize it as MAIN_444_10 */
+        profile = GST_VAAPI_PROFILE_H265_MAIN_444_10;
+        break;
+      } else if (sps->profile_tier_level.max_12bit_constraint_flag == 1
+          && sps->profile_tier_level.max_10bit_constraint_flag == 1
+          && sps->profile_tier_level.max_8bit_constraint_flag == 0
+          && sps->profile_tier_level.max_422chroma_constraint_flag == 1
+          && sps->profile_tier_level.max_420chroma_constraint_flag == 0
+          && sps->profile_tier_level.max_monochrome_constraint_flag == 0
+          && sps->profile_tier_level.intra_constraint_flag == 1
+          && sps->profile_tier_level.one_picture_only_constraint_flag == 0) {
+        /* Main 422_10 Intra, recognize it as MAIN_422_10 */
+        profile = GST_VAAPI_PROFILE_H265_MAIN_422_10;
+        break;
       }
     default:
       GST_DEBUG ("unsupported profile_idc value");

--- a/gst/vaapi/gstvaapidecode.c
+++ b/gst/vaapi/gstvaapidecode.c
@@ -1267,9 +1267,36 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
       continue;
 
     profile_name = gst_vaapi_profile_get_name (profile);
-    if (profile_name)
-      gst_structure_set (structure, "profile", G_TYPE_STRING,
-          profile_name, NULL);
+    if (profile_name) {
+      GValue list_value = G_VALUE_INIT;
+      GValue value = G_VALUE_INIT;
+      g_value_init (&list_value, GST_TYPE_LIST);
+      g_value_init (&value, G_TYPE_STRING);
+      g_value_set_string (&value, profile_name);
+      gst_value_list_append_value (&list_value, &value);
+
+      /* Add all according -intra profile for HEVC */
+      if (profile == GST_VAAPI_PROFILE_H265_MAIN) {
+        g_value_set_string (&value, "main-intra");
+        gst_value_list_append_value (&list_value, &value);
+      } else if (profile == GST_VAAPI_PROFILE_H265_MAIN10) {
+        g_value_set_string (&value, "main-10-intra");
+        gst_value_list_append_value (&list_value, &value);
+      } else if (profile == GST_VAAPI_PROFILE_H265_MAIN_422_10) {
+        g_value_set_string (&value, "main-422-10-intra");
+        gst_value_list_append_value (&list_value, &value);
+      } else if (profile == GST_VAAPI_PROFILE_H265_MAIN_444) {
+        g_value_set_string (&value, "main-444-intra");
+        gst_value_list_append_value (&list_value, &value);
+      } else if (profile == GST_VAAPI_PROFILE_H265_MAIN_444_10) {
+        g_value_set_string (&value, "main-444-10-intra");
+        gst_value_list_append_value (&list_value, &value);
+      }
+
+      gst_structure_set_value (structure, "profile", &list_value);
+      g_value_unset (&list_value);
+      g_value_unset (&value);
+    }
 
     gst_vaapi_profile_caps_append_decoder (display, profile, structure);
 


### PR DESCRIPTION
In hevc, we can consider the -intra profile a subset of the none
-intra profile. The -intra profiles just contain I frames and we
definitely can use the none -intra profiles's context to decode
them.