### PR TITLE
vaapidecoder: h264: remove baseline as constrained property

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
@@ -1331,6 +1331,7 @@ gst_vaapi_decoder_h264_create (GstVaapiDecoder * base_decoder)
   priv->prev_pic_structure = GST_VAAPI_PICTURE_STRUCTURE_FRAME;
   priv->progressive_sequence = TRUE;
   priv->top_field_first = FALSE;
+  priv->baseline_as_constrained = TRUE;
   return TRUE;
 }
 
@@ -4799,24 +4800,6 @@ gst_vaapi_decoder_h264_set_base_only (GstVaapiDecoderH264 * decoder,
   g_return_if_fail (decoder != NULL);
 
   decoder->priv.base_only = base_only;
-}
-
-/**
- * gst_vaapi_decoder_h264_set_baseline_as_constrained:
- * @decoder: a #GstVaapiDecoderH264
- * @baseline_as_constrained: %TRUE to assume all baseline is constrained
- *
- * This is a small hack that makes the decoder assumes that baseline contents
- * is already constrained. This may allow decoding some streams that would
- * otherwise fails to negotiation.
- */
-void
-gst_vaapi_decoder_h264_set_baseline_as_constrained (GstVaapiDecoderH264 *
-    decoder, gboolean baseline_as_constrained)
-{
-  g_return_if_fail (decoder != NULL);
-
-  decoder->priv.baseline_as_constrained = baseline_as_constrained;
 }
 
 /**

--- a/gst-libs/gst/vaapi/gstvaapidecoder_h264.h
+++ b/gst-libs/gst/vaapi/gstvaapidecoder_h264.h
@@ -73,10 +73,6 @@ void
 gst_vaapi_decoder_h264_set_base_only(GstVaapiDecoderH264 * decoder,
     gboolean base_only);
 
-void
-gst_vaapi_decoder_h264_set_baseline_as_constrained(GstVaapiDecoderH264 * decoder,
-    gboolean baseline_as_constrained);
-
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GstVaapiDecoderH264, gst_object_unref)
 
 G_END_DECLS

--- a/gst/vaapi/gstvaapidecode.c
+++ b/gst/vaapi/gstvaapidecode.c
@@ -909,9 +909,6 @@ gst_vaapidecode_create (GstVaapiDecode * decode, GstCaps * caps)
               (decode->decoder), priv->is_low_latency);
           gst_vaapi_decoder_h264_set_base_only (GST_VAAPI_DECODER_H264
               (decode->decoder), priv->base_only);
-          gst_vaapi_decoder_h264_set_baseline_as_constrained
-              (GST_VAAPI_DECODER_H264 (decode->decoder),
-              priv->baseline_as_constrained);
         }
       }
       break;
@@ -1233,8 +1230,6 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
   gboolean have_high = FALSE;
   gboolean have_mvc = FALSE;
   gboolean have_svc = FALSE;
-  GstVaapiDecodeH264Private *priv =
-      gst_vaapi_decode_h264_get_instance_private (decode);
 
   profiles = gst_vaapi_display_get_decode_profiles (display);
   if (!profiles)
@@ -1303,8 +1298,7 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
     have_svc |= is_svc_profile (profile);
     have_high |= profile == GST_VAAPI_PROFILE_H264_HIGH;
 
-    if (priv && priv->baseline_as_constrained &&
-        profile == GST_VAAPI_PROFILE_H264_CONSTRAINED_BASELINE)
+    if (profile == GST_VAAPI_PROFILE_H264_CONSTRAINED_BASELINE)
       allowed_sinkpad_caps =
           add_h264_profile_in_caps (allowed_sinkpad_caps, "baseline");
   }

--- a/gst/vaapi/gstvaapidecode_props.c
+++ b/gst/vaapi/gstvaapidecode_props.c
@@ -30,7 +30,6 @@ enum
 {
   GST_VAAPI_DECODER_H264_PROP_FORCE_LOW_LATENCY = 1,
   GST_VAAPI_DECODER_H264_PROP_BASE_ONLY,
-  GST_VAAPI_DECODER_H264_PROP_BASELINE_AS_CONSTRAINED,
 };
 
 static gint h264_private_offset;
@@ -49,9 +48,6 @@ gst_vaapi_decode_h264_get_property (GObject * object, guint prop_id,
       break;
     case GST_VAAPI_DECODER_H264_PROP_BASE_ONLY:
       g_value_set_boolean (value, priv->base_only);
-      break;
-    case GST_VAAPI_DECODER_H264_PROP_BASELINE_AS_CONSTRAINED:
-      g_value_set_boolean (value, priv->baseline_as_constrained);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -81,13 +77,6 @@ gst_vaapi_decode_h264_set_property (GObject * object, guint prop_id,
       if (decoder)
         gst_vaapi_decoder_h264_set_base_only (decoder, priv->base_only);
       break;
-    case GST_VAAPI_DECODER_H264_PROP_BASELINE_AS_CONSTRAINED:
-      priv->baseline_as_constrained = g_value_get_boolean (value);
-      decoder = GST_VAAPI_DECODER_H264 (GST_VAAPIDECODE (object)->decoder);
-      if (decoder)
-        gst_vaapi_decoder_h264_set_baseline_as_constrained (decoder,
-            priv->baseline_as_constrained);
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -113,13 +102,6 @@ gst_vaapi_decode_h264_install_properties (GObjectClass * klass)
   g_object_class_install_property (klass, GST_VAAPI_DECODER_H264_PROP_BASE_ONLY,
       g_param_spec_boolean ("base-only", "Decode base view only",
           "Drop any NAL unit not defined in Annex.A", FALSE,
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property (klass,
-      GST_VAAPI_DECODER_H264_PROP_BASELINE_AS_CONSTRAINED,
-      g_param_spec_boolean ("baseline-as-constrained",
-          "Baseline as Constrained",
-          "Assume all baseline content is also constrained.", FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 

--- a/gst/vaapi/gstvaapidecode_props.h
+++ b/gst/vaapi/gstvaapidecode_props.h
@@ -34,7 +34,6 @@ struct _GstVaapiDecodeH264Private
 {
   gboolean is_low_latency;
   gboolean base_only;
-  gboolean baseline_as_constrained;
 };
 
 void


### PR DESCRIPTION
From now on always the baseline is going to be treated as constrained without
need of setting a property.

Since the property was added along the development cycle (1.17) and never
released, we assume that it is safe to remove it.

Fixes: #252