### PR TITLE
plugin: encode: correct ensure_allowed_sinkpad_caps's caps.

### DIFF
--- a/gst/vaapi/gstvaapidecode.c
+++ b/gst/vaapi/gstvaapidecode.c
@@ -1184,6 +1184,7 @@ static gboolean
 gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
 {
   GstCaps *caps, *allowed_sinkpad_caps;
+  GstPad *const sinkpad = GST_VIDEO_DECODER_SINK_PAD (decode);
   GArray *profiles;
   GstVaapiDisplay *const display = GST_VAAPI_PLUGIN_BASE_DISPLAY (decode);
   guint i;
@@ -1301,7 +1302,14 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
           add_h264_profile_in_caps (allowed_sinkpad_caps, "scalable-high");
     }
   }
-  decode->allowed_sinkpad_caps = gst_caps_simplify (allowed_sinkpad_caps);
+
+  caps = gst_pad_get_pad_template_caps (sinkpad);
+  g_assert (caps);
+  decode->allowed_sinkpad_caps =
+      gst_caps_intersect (allowed_sinkpad_caps, caps);
+  gst_caps_unref (caps);
+  decode->allowed_sinkpad_caps =
+      gst_caps_simplify (decode->allowed_sinkpad_caps);
   GST_DEBUG_OBJECT (decode, "allowed sink caps %" GST_PTR_FORMAT,
       decode->allowed_sinkpad_caps);
 


### PR DESCRIPTION
The allowed caps returned by ensure_allowed_sinkpad_caps() contains
all profiles of the whole VAAPI, like:
  image/jpeg, width=(int)[ 0, 1638 4 ], height=(int)[ 0, 16384 ];
  video/mpeg, mpegversion=(int)2, profile=(string){ simple, main },
  width=(int)[ 0, 2048 ], height=(int)[ 0, 2048 ]; video/x-h264,
  profile=(string){ main, high, constrained-baseline }, width=(int)[ 0,
  4096 ], height=(int)[ 0, 4096 ]; video/x-h264, profile=(string){
  constrained-high, progressive-high, baseline }; video/x-h265,
  profile=(string){ main, main-intra }, width=(int)[ 0, 8192 ],
  height=(int)[ 0, 8192 ]; video/x-vp8, width=(int)[ 0, 4096 ],
  height=(int)[ 0, 4096 ]; video/x-wmv, wmvversion=(int)3,
  format=(string)WVC1, profile=(string)advanced, width=(int)[ 0, 3840 ],
  height=(int)[ 0, 3840 ]; video/x-wmv, wmvversion=(int)3,
  profile=(string){ simple, main }, width=(int)[ 0, 3840 ],
  height=(int)[ 0, 3840 ]

Which is verbose and may have latent problems. It should only contains
the profiles belong to its codec type. For example, h265 should only
return:
  video/x-h265, profile=(string){ main, main-intra },
  width=(int)[ 0, 8192 ], height=(int)[ 0, 8192 ]