### PR TITLE
vaapidecode: always merge profile caps in sink caps

### DIFF
--- a/gst/vaapi/gstvaapidecode.c
+++ b/gst/vaapi/gstvaapidecode.c
@@ -1289,7 +1289,7 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
 
     profile_name = gst_vaapi_profile_get_name (profile);
     if (!profile_name)
-      continue;
+      goto merge_caps;
 
     /* Add all according -intra profile for HEVC */
     if (profile == GST_VAAPI_PROFILE_H265_MAIN
@@ -1346,8 +1346,8 @@ gst_vaapidecode_ensure_allowed_sinkpad_caps (GstVaapiDecode * decode)
           profile_name, NULL);
     }
 
+  merge_caps:
     gst_vaapi_profile_caps_append_decoder (display, profile, structure);
-
     allowed_sinkpad_caps = gst_caps_merge (allowed_sinkpad_caps, caps);
   }
 


### PR DESCRIPTION
This commit fixes a regression of e962069d, where if the profile's
caps doesn't have a caps profile, it's ignored.

This patch add a conditional jump if the caps doesn't have a profile
field to merge it.

Fixes: #271